### PR TITLE
QA-11573: Fix character encoding in generated XML files

### DIFF
--- a/configurators/src/main/java/org/jahia/configuration/configurators/AbstractXMLConfigurator.java
+++ b/configurators/src/main/java/org/jahia/configuration/configurators/AbstractXMLConfigurator.java
@@ -47,8 +47,11 @@ import org.jahia.configuration.logging.AbstractLogger;
 import org.jdom.Document;
 import org.jdom.Element;
 import org.jdom.JDOMException;
+import org.jdom.output.Format;
+import org.jdom.output.XMLOutputter;
 import org.jdom.xpath.XPath;
 
+import java.io.*;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.List;
@@ -190,4 +193,38 @@ public abstract class AbstractXMLConfigurator extends AbstractConfigurator {
             el.getParent().removeContent(el);
         }
     }
+
+    /**
+     * Write a JDom document to a file.
+     *
+     * <p>Characters will be encoded using UTF-8
+     *
+     * @param document the document to write
+     * @param destination the file to write to
+     * @throws IOException if an error occurs while writing the document
+     */
+    protected final void write(Document document, File destination) throws IOException {
+        String lineSeparator = System.getProperty("line.separator");
+        Format format = Format.getPrettyFormat().setLineSeparator(lineSeparator);
+
+        write(document, destination, format);
+    }
+
+    /**
+     * Write a JDom document to a file.
+     *
+     * <P>Characters will be encoded using {@link Format#getEncoding()}
+     *
+     * @param document the document to write
+     * @param destination the file to write to
+     * @param format the format to apply
+     * @throws IOException if an error occurs while writing the document
+     */
+    protected final void write(Document document, File destination, Format format) throws IOException {
+        XMLOutputter outputter = new XMLOutputter(format);
+        try (OutputStream out = new FileOutputStream(destination)) {
+            outputter.output(document, out);
+        }
+    }
+
 }

--- a/configurators/src/main/java/org/jahia/configuration/configurators/ApplicationXmlConfigurator.java
+++ b/configurators/src/main/java/org/jahia/configuration/configurators/ApplicationXmlConfigurator.java
@@ -47,10 +47,8 @@ import org.codehaus.plexus.util.StringUtils;
 import org.jdom.Element;
 import org.jdom.Namespace;
 import org.jdom.input.SAXBuilder;
-import org.jdom.output.Format;
-import org.jdom.output.XMLOutputter;
 
-import java.io.FileWriter;
+import java.io.File;
 import java.io.InputStreamReader;
 
 /**
@@ -114,11 +112,7 @@ public class ApplicationXmlConfigurator extends AbstractXMLConfigurator {
             }
         }
 
-        Format customFormat = Format.getPrettyFormat();
-        customFormat.setLineSeparator(System.getProperty("line.separator"));
-        XMLOutputter xmlOutputter = new XMLOutputter(customFormat);
-        xmlOutputter.output(jdomDocument, new FileWriter(destFileName));
-
+        write(jdomDocument, new File(destFileName));
     }
 
     private void createModuleTypeContent(String[] moduleParams, Element moduleType) {

--- a/configurators/src/main/java/org/jahia/configuration/configurators/JBossConfigurator.java
+++ b/configurators/src/main/java/org/jahia/configuration/configurators/JBossConfigurator.java
@@ -61,8 +61,6 @@ import org.jdom.JDOMException;
 import org.jdom.Namespace;
 import org.jdom.input.SAXBuilder;
 import org.jdom.output.Format;
-import org.jdom.output.Format.TextMode;
-import org.jdom.output.XMLOutputter;
 
 /**
  * JBoss DB datasource configurator.
@@ -209,14 +207,6 @@ public class JBossConfigurator extends AbstractXMLConfigurator {
         return StringUtils.replace(getValue(dbProperties, prop), "=", "\\=");
     }
 
-    private Format getOutputFormat() {
-        Format customFormat = Format.getRawFormat();
-        customFormat.setTextMode(TextMode.TRIM);
-        customFormat.setIndent("    ");
-        customFormat.setLineSeparator(System.getProperty("line.separator"));
-        return customFormat;
-    }
-
     private Element getProfile(Element root, ConfigFile sourceConfigFile) {
         Element profile = root.getChild("profile", root.getNamespace());
         if (profile == null) {
@@ -270,9 +260,11 @@ public class JBossConfigurator extends AbstractXMLConfigurator {
             
             configureConnector(profile);
 
-            out = new FileWriter(destFileName);
             getLogger().info("Writing output to " + destFileName);
-            new XMLOutputter(getOutputFormat()).output(jdomDocument, out);
+            write(jdomDocument, new File(destFileName), Format.getPrettyFormat()
+                    .setIndent("    ")
+                    .setLineSeparator(System.getProperty("line.separator"))
+            );
 
         } catch (JDOMException jdome) {
             throw new Exception("Error while updating configuration file " + sourceConfigFile, jdome);

--- a/configurators/src/main/java/org/jahia/configuration/configurators/JackrabbitConfigurator.java
+++ b/configurators/src/main/java/org/jahia/configuration/configurators/JackrabbitConfigurator.java
@@ -46,12 +46,10 @@ package org.jahia.configuration.configurators;
 import org.codehaus.plexus.util.StringUtils;
 import org.jahia.configuration.logging.AbstractLogger;
 import org.jdom.*;
-import org.jdom.output.XMLOutputter;
-import org.jdom.output.Format;
 import org.jdom.xpath.XPath;
 import org.jdom.input.SAXBuilder;
 
-import java.io.FileWriter;
+import java.io.File;
 import java.io.InputStreamReader;
 import java.util.Map;
 import java.util.List;
@@ -123,11 +121,8 @@ public class JackrabbitConfigurator extends AbstractXMLConfigurator {
             	removeElementIfExists(repositoryElement, "//Versioning/FileSystem/param[@name=\"schemaCheckEnabled\"]");
             	fs.addContent(new Element("param", namespace).setAttribute("name", "path").setAttribute("value", "${rep.home}/version"));
             }
-            
-            Format customFormat = Format.getPrettyFormat();
-            customFormat.setLineSeparator(System.getProperty("line.separator"));
-            XMLOutputter xmlOutputter = new XMLOutputter(customFormat);
-            xmlOutputter.output(jdomDocument, new FileWriter(destFileName));
+
+            write(jdomDocument, new File(destFileName));
 
         } catch (JDOMException jdome) {
             throw new Exception("Error while updating configuration file " + sourceConfigFile, jdome);

--- a/configurators/src/main/java/org/jahia/configuration/configurators/MailServerConfigurator.java
+++ b/configurators/src/main/java/org/jahia/configuration/configurators/MailServerConfigurator.java
@@ -47,10 +47,8 @@ import org.jdom.Document;
 import org.jdom.Element;
 import org.jdom.Namespace;
 import org.jdom.input.SAXBuilder;
-import org.jdom.output.Format;
-import org.jdom.output.XMLOutputter;
 
-import java.io.FileWriter;
+import java.io.File;
 import java.util.Map;
 
 /**
@@ -93,15 +91,6 @@ public class MailServerConfigurator extends AbstractXMLConfigurator {
             }
         }
 
-        Format customFormat = Format.getPrettyFormat();
-        customFormat.setLineSeparator(System.getProperty("line.separator"));
-        XMLOutputter xmlOutputter = new XMLOutputter(customFormat);
-        FileWriter out = new FileWriter(destFileName);
-        try {
-            xmlOutputter.output(jdomDocument, out);
-        } finally {
-            out.close();
-        }
-
+        write(jdomDocument, new File(destFileName));
     }
 }

--- a/configurators/src/main/java/org/jahia/configuration/configurators/RootUserConfigurator.java
+++ b/configurators/src/main/java/org/jahia/configuration/configurators/RootUserConfigurator.java
@@ -47,10 +47,8 @@ import org.jdom.Document;
 import org.jdom.Element;
 import org.jdom.Namespace;
 import org.jdom.input.SAXBuilder;
-import org.jdom.output.Format;
-import org.jdom.output.XMLOutputter;
 
-import java.io.FileWriter;
+import java.io.File;
 import java.util.Map;
 
 /**
@@ -111,10 +109,6 @@ public class RootUserConfigurator extends AbstractXMLConfigurator {
             }
         }
 
-        Format customFormat = Format.getPrettyFormat();
-        customFormat.setLineSeparator(System.getProperty("line.separator"));
-        XMLOutputter xmlOutputter = new XMLOutputter(customFormat);
-        xmlOutputter.output(jdomDocument, new FileWriter(destFileName));
-
+        write(jdomDocument, new File(destFileName));
     }
 }

--- a/configurators/src/main/java/org/jahia/configuration/configurators/TomcatContextXmlConfigurator.java
+++ b/configurators/src/main/java/org/jahia/configuration/configurators/TomcatContextXmlConfigurator.java
@@ -46,11 +46,9 @@ package org.jahia.configuration.configurators;
 import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.jdom.input.SAXBuilder;
-import org.jdom.output.Format;
-import org.jdom.output.XMLOutputter;
 import org.jdom.xpath.XPath;
 
-import java.io.FileWriter;
+import java.io.File;
 import java.io.InputStreamReader;
 import java.util.Map;
 
@@ -98,10 +96,7 @@ public class TomcatContextXmlConfigurator extends AbstractXMLConfigurator {
             	resource.setAttribute("validationQuery", getValue(dbProperties, "jahia.database.validationQuery"));
             }
 
-            Format customFormat = Format.getPrettyFormat();
-            customFormat.setLineSeparator(System.getProperty("line.separator"));
-            XMLOutputter xmlOutputter = new XMLOutputter(customFormat);
-            xmlOutputter.output(jdomDocument, new FileWriter(destFileName));
+            write(jdomDocument, new File(destFileName));
 
         } catch (JDOMException jdome) {
             throw new Exception("Error while updating configuration file " + sourceConfigFile, jdome);


### PR DESCRIPTION
Use JDom's XMLOutputter.output(Document doc, OutputStream out) instead
of XMLOutput.output(Document doc, Writer out) so that character encoding
of generated files is consistent with the one specified in the XML header
(this will leverage Format.getEncoding() which defaults to UTF-8).

The former implementation was using XMLOutput.output(Document doc, Writer out)
and a FileWriter which was encoding the character using the default system
encoding (Charset.defaultCharset()), thus leading to inconsistent results.