### PR TITLE
BACKLOG-12123: Remove DB version display

### DIFF
--- a/configurators/src/test/resources/configurators/WEB-INF/var/db/mysql.script
+++ b/configurators/src/test/resources/configurators/WEB-INF/var/db/mysql.script
@@ -1,6 +1,6 @@
 # Jahia MySQL Database configuration file
 
-jahia.database.name     =  MySQL 5.x
+jahia.database.name     =  MySQL
 jahia.database.driver   =  com.mysql.jdbc.Driver
 jahia.database.url      =  jdbc:mysql://localhost/jahia?useUnicode=true&characterEncoding=UTF-8&useServerPrepStmts=false
 jahia.database.user     =  jahia

--- a/configurators/src/test/resources/configurators/WEB-INF/var/db/oracle.script
+++ b/configurators/src/test/resources/configurators/WEB-INF/var/db/oracle.script
@@ -1,6 +1,6 @@
 # Jahia Oracle Database configuration file
 
-jahia.database.name     =  Oracle 10g / 11g
+jahia.database.name     =  Oracle
 jahia.database.driver   =  oracle.jdbc.OracleDriver
 jahia.database.url      =  jdbc:oracle:thin:@localhost:1521:jahia
 jahia.database.user     =  jahia


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-12123

## Description

Remove the DB version display as for now same config is used for multiple versions.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

I have considered the following implications of my change: 

- [X] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [X] Performance
- [X] Migration
- [X] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
