### PR TITLE
TECH-327: Fix Jahia-depends version dependency bug

### DIFF
--- a/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/osgi/models/JahiaDepends.java
+++ b/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/osgi/models/JahiaDepends.java
@@ -51,7 +51,7 @@ public class JahiaDepends {
 
     public boolean hasVersion() {
         return StringUtils.isNotEmpty(getMinVersion())
-                && StringUtils.isNotEmpty(getMaxVersion());
+                || StringUtils.isNotEmpty(getMaxVersion());
     }
 
 

--- a/maven-jahia-plugin/src/test/java/org/jahia/utils/maven/plugin/osgi/models/JahiaDependsTest.java
+++ b/maven-jahia-plugin/src/test/java/org/jahia/utils/maven/plugin/osgi/models/JahiaDependsTest.java
@@ -23,6 +23,7 @@
  */
 package org.jahia.utils.maven.plugin.osgi.models;
 
+import org.apache.commons.lang.StringUtils;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -37,6 +38,7 @@ public class JahiaDependsTest {
         assertEquals(moduleName, depends.getModuleName());
         assertEquals(min, depends.getMinVersion());
         assertEquals(max, depends.getMaxVersion());
+        assertEquals(StringUtils.isNotEmpty(min) || StringUtils.isNotEmpty(max), depends.hasVersion());
         assertEquals(filterString, depends.toFilterString());
     }
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-327

## Description

Related to https://github.com/Jahia/jahia-private/pull/766

Fix bug in logic that checks if a Jahia dependency has a version parameter. This was not returning correctly for a lower-bound check (returning false) which is showing no error message (false positive) on the module-manager since it wasn't checking version restriction.

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [x] Unit Tests (Most changes _should_ have unit tests)