### PR TITLE
QA-13725: Add xmlParserAPIs dependency as the resolved one is too old

### DIFF
--- a/configurators/pom.xml
+++ b/configurators/pom.xml
@@ -71,6 +71,11 @@
             <artifactId>plexus-archiver</artifactId>
             <version>1.0-alpha-12</version>
         </dependency>
+	    <dependency>
+	        <groupId>xerces</groupId>
+            <artifactId>xmlParserAPIs</artifactId>
+            <version>2.11.0</version>
+        </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/QA-13725

## Description

Add xmlParserAPIs dependency as the resolved one is too old