### PR TITLE
BACKLOG-16819: force overwrite when deploying data package

### DIFF
--- a/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/DeployMojo.java
+++ b/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/DeployMojo.java
@@ -48,7 +48,6 @@ import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
 import com.github.dockerjava.core.DockerClientConfig;
 import com.github.dockerjava.core.DockerClientImpl;
-import com.github.dockerjava.core.command.ExecStartResultCallback;
 import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
 import com.github.dockerjava.transport.DockerHttpClient;
 import com.sun.jdi.Bootstrap;
@@ -662,6 +661,7 @@ public class DeployMojo extends AbstractManagementMojo {
             unarch.enableLogging(getLog().isDebugEnabled() ? new ConsoleLogger(
                     Logger.LEVEL_DEBUG, "console") : new ConsoleLogger());
             unarch.setDestDirectory(getDataDir());
+            unarch.setOverwrite(true);
             unarch.extract();
             getLog().info("...done.");
         } catch (Exception e) {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16819

## Description
If not using overwrite, if the data-package from jahia-war is newer than the one from jahia-ee on nexus you will not have the license-tools nor the clustering
