### PR TITLE
BACKLOG-16819: Plexus Archiver library refuse to overwrite files that…

### DIFF
--- a/maven-jahia-plugin/pom.xml
+++ b/maven-jahia-plugin/pom.xml
@@ -393,6 +393,11 @@
 			<scope>compile</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>net.lingala.zip4j</groupId>
+			<artifactId>zip4j</artifactId>
+			<version>2.9.1</version>
+		</dependency>
 
 	</dependencies>
 

--- a/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/DeployMojo.java
+++ b/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/DeployMojo.java
@@ -57,6 +57,8 @@ import com.sun.jdi.connect.AttachingConnector;
 import com.sun.jdi.connect.Connector;
 import com.sun.jdi.connect.Connector.Argument;
 import com.sun.jdi.connect.IllegalConnectorArgumentsException;
+import net.lingala.zip4j.ZipFile;
+import net.lingala.zip4j.model.UnzipParameters;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.io.FileUtils;
@@ -117,8 +119,8 @@ public class DeployMojo extends AbstractManagementMojo {
 
     private static final Set<String> JAHIA_PACKAGE_PROJECTS = new HashSet<String>(
             Arrays.asList("jahia-data", "jahia-core-modules",
-                          "jahia-additional-modules", "jahia-ee-data",
-                          "jahia-ee-core-modules", "jahia-ee-additional-modules"));
+                    "jahia-additional-modules", "jahia-ee-data",
+                    "jahia-ee-core-modules", "jahia-ee-additional-modules"));
 
     /**
      * The dependency tree builder to use.
@@ -197,7 +199,7 @@ public class DeployMojo extends AbstractManagementMojo {
                     String dockerDatadir = "/var/jahia";
                     String[] env = dockerClient.inspectContainerCmd(targetContainerName).exec().getConfig().getEnv();
                     for (String s : env) {
-                        if(s.startsWith("DATA_FOLDER=")) {
+                        if (s.startsWith("DATA_FOLDER=")) {
                             getLog().info("Found DATA_FOLDER env variable in container " + targetContainerName + ", using it for deployment: " + s);
                             dockerDatadir = s.split("=")[1];
                         }
@@ -334,7 +336,7 @@ public class DeployMojo extends AbstractManagementMojo {
         }
 
         for (File info : FileUtils.listFiles(deployedBundeDir, new NameFileFilter("bundle.info"),
-                                             TrueFileFilter.INSTANCE)) {
+                TrueFileFilter.INSTANCE)) {
             try {
                 if (FileUtils.readFileToString(info).contains(fileName)) {
                     try {
@@ -427,7 +429,7 @@ public class DeployMojo extends AbstractManagementMojo {
             try {
                 ZipUnArchiver unarch = new ZipUnArchiver(new File(output, project.getBuild().getFinalName() + ".war"));
                 unarch.enableLogging(getLog().isDebugEnabled() ? new ConsoleLogger(Logger.LEVEL_DEBUG, "console")
-                                             : new ConsoleLogger());
+                        : new ConsoleLogger());
                 if (!webappDir.exists() && !webappDir.mkdirs()) {
                     throw new IOException("Unable to create target WAR directory " + webappDir);
                 }
@@ -573,7 +575,7 @@ public class DeployMojo extends AbstractManagementMojo {
                             deployPackageFromDepenendency(artifact);
                         }
                     } else if (artifact.getGroupId()
-                                       .equals("org.jahia.modules")
+                            .equals("org.jahia.modules")
                             || (deployTests && artifact.getGroupId().equals(
                             "org.jahia.test"))
                             || artifact.getGroupId().endsWith(".jahia.modules")) {
@@ -604,15 +606,15 @@ public class DeployMojo extends AbstractManagementMojo {
 
             if (project.getAttachedArtifacts().size() > 0) {
                 Artifact artifact = (Artifact) project.getAttachedArtifacts()
-                                                      .get(project.getAttachedArtifacts().size() - 1);
+                        .get(project.getAttachedArtifacts().size() - 1);
                 artifactResolver.resolve(artifact,
-                                         project.getRemoteArtifactRepositories(),
-                                         localRepository);
+                        project.getRemoteArtifactRepositories(),
+                        localRepository);
                 file = artifact.getFile();
             } else {
                 file = getAetherHelper().resolveArtifactFile(project.getGroupId() + ":" + project.getArtifactId()
-                                                                     + ":zip:package:"
-                                                                     + project.getArtifact().getVersion());
+                        + ":zip:package:"
+                        + project.getArtifact().getVersion());
             }
             getLog().info("...resolved to: " + file);
 
@@ -639,14 +641,14 @@ public class DeployMojo extends AbstractManagementMojo {
         File file = null;
         getLog().info("Resolving artifact file...");
         file = getAetherHelper().resolveArtifactFile(artifact.getGroupId()
-                                                             + ":"
-                                                             + artifact.getArtifactId()
-                                                             + ":"
-                                                             + artifact.getType()
-                                                             + ":"
-                                                             + (StringUtils.isNotEmpty(artifact.getClassifier()) ? (artifact
+                + ":"
+                + artifact.getArtifactId()
+                + ":"
+                + artifact.getType()
+                + ":"
+                + (StringUtils.isNotEmpty(artifact.getClassifier()) ? (artifact
                 .getClassifier() + ":") : "")
-                                                             + artifact.getVersion());
+                + artifact.getVersion());
         getLog().info("...resolved to: " + file);
         return file;
     }
@@ -656,13 +658,10 @@ public class DeployMojo extends AbstractManagementMojo {
                 "Deploying Digital Experience Manager data package file "
                         + packageFile + "...");
         try {
-            getLog().info("Extracting content to data directory " + getDataDir() + "...");
-            ZipUnArchiver unarch = new ZipUnArchiver(packageFile);
-            unarch.enableLogging(getLog().isDebugEnabled() ? new ConsoleLogger(
-                    Logger.LEVEL_DEBUG, "console") : new ConsoleLogger());
-            unarch.setDestDirectory(getDataDir());
-            unarch.setOverwrite(true);
-            unarch.extract();
+            getLog().info("Extracting content to data directory with overwrite " + getDataDir() + "...");
+            try (ZipFile file = new ZipFile(packageFile)) {
+                file.extractAll(getDataDir().getAbsolutePath());
+            }
             getLog().info("...done.");
         } catch (Exception e) {
             getLog().error(e);
@@ -671,19 +670,19 @@ public class DeployMojo extends AbstractManagementMojo {
 
     protected DependencyNode getRootDependencyNode() throws DependencyTreeBuilderException {
         return dependencyTreeBuilder.buildDependencyTree(project, localRepository, artifactFactory,
-                                                         artifactMetadataSource, null, artifactCollector);
+                artifactMetadataSource, null, artifactCollector);
     }
 
 
     private void deploySharedLibraries(DependencyNode dependencyNode)
             throws IOException, ArtifactResolutionException,
-                   ArtifactNotFoundException {
+            ArtifactNotFoundException {
         boolean jdbcDrivers = dependencyNode.getArtifact().getArtifactId().startsWith("jdbc-drivers");
         for (DependencyNode node : ((List<DependencyNode>) dependencyNode.getChildren())) {
             Artifact artifact = node.getArtifact();
 
             artifactResolver.resolve(artifact,
-                                     project.getRemoteArtifactRepositories(), localRepository);
+                    project.getRemoteArtifactRepositories(), localRepository);
             try {
                 if (jdbcDrivers) {
                     deployJdbcDriver(artifact);
@@ -720,8 +719,8 @@ public class DeployMojo extends AbstractManagementMojo {
                 "Deploying artifact " + artifact.getGroupId() + ":" + artifact.getArtifactId() + ":"
                         + artifact.getVersion() + "(file: " + artifact.getFile() + ")");
         getLog().info("Updating " + artifact.getType() +
-                              " resources for " + getDeployer().getName() +
-                              " in directory " + webappDir);
+                " resources for " + getDeployer().getName() +
+                " in directory " + webappDir);
 
         String[] excludes = getDeployer().getWarExcludes() != null ? StringUtils.split(getDeployer().getWarExcludes(), ",") : null;
 


### PR DESCRIPTION


<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16819

## Description

Plexus Archiver library refuse to overwrite files that are newer on disk with the ones coming from the archive. Switching to Zip4J which has the expected behaviour

