### PR TITLE
QA-14241: Do not load external dtd

### DIFF
--- a/configurators/src/main/java/org/jahia/configuration/configurators/JackrabbitConfigurator.java
+++ b/configurators/src/main/java/org/jahia/configuration/configurators/JackrabbitConfigurator.java
@@ -47,6 +47,7 @@ import org.codehaus.plexus.util.StringUtils;
 import org.jahia.configuration.logging.AbstractLogger;
 import org.jdom2.*;
 import org.jdom2.filter.Filters;
+import org.jdom2.input.sax.XMLReaders;
 import org.jdom2.xpath.XPath;
 import org.jdom2.input.SAXBuilder;
 import org.jdom2.xpath.XPathExpression;
@@ -81,6 +82,7 @@ public class JackrabbitConfigurator extends AbstractXMLConfigurator {
             saxBuilder.setFeature("http://apache.org/xml/features/disallow-doctype-decl",false);
             saxBuilder.setFeature("http://xml.org/sax/features/external-general-entities", true);
             saxBuilder.setFeature("http://xml.org/sax/features/external-parameter-entities", true);
+            saxBuilder.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
             saxBuilder.setExpandEntities(false);
 
             InputStreamReader fileReader = new InputStreamReader(sourceConfigFile.getInputStream());


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14241

## Description
During installation offline with the installer, in the install.log files we have this error
`     [java] Configuring for server tomcat with database type derby_embedded
     [java] Deployed in standalone for server in /Applications/Jahia-EnterpriseDistribution-8.1.2.0-SNAPSHOT/tomcat/webapps/ROOT
     [java] Data directory resolved to folder: /Applications/Jahia-EnterpriseDistribution-8.1.2.0-SNAPSHOT/digital-factory-data
     [java] Updating configuration files...
     [java] Configuring file using source /Applications/Jahia-EnterpriseDistribution-8.1.2.0-SNAPSHOT/tomcat/webapps/ROOT to target /Applications/Jahia-EnterpriseDistribution-8.1.2.0-SNAPSHOT/tomcat/webapps/ROOT
     [java] Error during execution of a configurator. Cause: jackrabbit.apache.org
     [java] java.net.UnknownHostException: jackrabbit.apache.org
     [java] 	at java.base/java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:229)
     [java] 	at java.base/java.net.Socket.connect(Socket.java:609)
     [java] 	at java.base/java.net.Socket.connect(Socket.java:558)
     [java] 	at java.base/sun.net.NetworkClient.doConnect(NetworkClient.java:182)
     [java] 	at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:474)
     [java] 	at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:569)
     [java] 	at java.base/sun.net.www.http.HttpClient.<init>(HttpClient.java:242)
     [java] 	at java.base/sun.net.www.http.HttpClient.New(HttpClient.java:341)
     [java] 	at java.base/sun.net.www.http.HttpClient.New(HttpClient.java:362)
     [java] 	at java.base/sun.net.www.protocol.http.HttpURLConnection.getNewHttpClient(HttpURLConnection.java:1253)
     [java] 	at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1187)
     [java] 	at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1081)
     [java] 	at java.base/sun.net.www.protocol.http.HttpURLConnection.connect(HttpURLConnection.java:1015)
     [java] 	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1592)
     [java] 	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1520)
     [java] 	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLEntityManager.setupCurrentEntity(XMLEntityManager.java:676)
     [java] 	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLEntityManager.startEntity(XMLEntityManager.java:1396)
     [java] 	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLEntityManager.startDTDEntity(XMLEntityManager.java:1362)
     [java] 	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDTDScannerImpl.setInputSource(XMLDTDScannerImpl.java:257)
     [java] 	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl$DTDDriver.dispatch(XMLDocumentScannerImpl.java:1152)
     [java] 	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl$DTDDriver.next(XMLDocumentScannerImpl.java:1040)
     [java] 	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl$PrologDriver.next(XMLDocumentScannerImpl.java:943)
     [java] 	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl.next(XMLDocumentScannerImpl.java:605)
     [java] 	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLNSDocumentScannerImpl.next(XMLNSDocumentScannerImpl.java:112)
     [java] 	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanDocument(XMLDocumentFragmentScannerImpl.java:534)
     [java] 	at java.xml/com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:888)
     [java] 	at java.xml/com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:824)
     [java] 	at java.xml/com.sun.org.apache.xerces.internal.parsers.XMLParser.parse(XMLParser.java:141)
     [java] 	at java.xml/com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.parse(AbstractSAXParser.java:1216)
     [java] 	at java.xml/com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl$JAXPSAXParser.parse(SAXParserImpl.java:635)
     [java] 	at org.jdom2.input.sax.SAXBuilderEngine.build(SAXBuilderEngine.java:217)
     [java] 	at org.jdom2.input.sax.SAXBuilderEngine.build(SAXBuilderEngine.java:303)
     [java] 	at org.jdom2.input.SAXBuilder.build(SAXBuilder.java:1196)
     [java] 	at org.jahia.configuration.configurators.JackrabbitConfigurator.updateConfiguration(JackrabbitConfigurator.java:88)
     [java] 	at org.jahia.configuration.configurators.JahiaGlobalConfigurator.updateConfigurationFiles(JahiaGlobalConfigurator.java:218)
     [java] 	at org.jahia.configuration.configurators.JahiaGlobalConfigurator.setProperties(JahiaGlobalConfigurator.java:456)
     [java] 	at org.jahia.configuration.configurators.JahiaGlobalConfigurator.execute(JahiaGlobalConfigurator.java:207)
     [java] 	at org.jahia.configuration.Main.main(Main.java:97)`

## Tests

The following are included in this PR
- [X] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests
