### PR TITLE
TECH-1057: Add support for optional jahia-depends dependencies

### DIFF
--- a/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/osgi/models/JahiaDepends.java
+++ b/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/osgi/models/JahiaDepends.java
@@ -37,6 +37,7 @@ public class JahiaDepends {
     private String moduleName = "";
     private VersionRange range = null;
     private String parsedString = null;
+    private boolean isOptional = false;
 
 
     public JahiaDepends(String dependency) {
@@ -45,13 +46,23 @@ public class JahiaDepends {
         this.moduleName = StringUtils.isNotBlank(deps[0]) ? deps[0].trim() : "";
 
         if (deps.length > 1 && StringUtils.isNotBlank(deps[1])) {
-            range = new VersionRange(deps[1]);
+            String rangeStr = deps[1];
+            rangeStr = rangeStr.replace(";optional", "");
+            rangeStr = rangeStr.replace("optional", "");
+            this.isOptional = !rangeStr.equals(deps[1]); // optional keyword existed and was removed
+            if (!rangeStr.isEmpty()) {
+                range = new VersionRange(rangeStr);
+            }
         }
     }
 
     public boolean hasVersion() {
         return StringUtils.isNotEmpty(getMinVersion())
                 || StringUtils.isNotEmpty(getMaxVersion());
+    }
+
+    public boolean isOptional() {
+        return this.isOptional;
     }
 
 

--- a/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/osgi/utils/CapabilityUtils.java
+++ b/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/osgi/utils/CapabilityUtils.java
@@ -39,7 +39,7 @@ import static org.jahia.utils.maven.plugin.osgi.utils.Constants.*;
  */
 public class CapabilityUtils {
 
-    static final String DELIMITER = ";";
+    static final String DELIMITER = "#"; // Anything except comma or semicolon
 
     public static void buildJahiaDependencies(MavenProject project, String jahiaDependsValue,
             Set<String> skipRequireDependencies, String prefix) throws MojoExecutionException {
@@ -75,8 +75,12 @@ public class CapabilityUtils {
         JahiaDepends depends = new JahiaDepends(dependency);
         if (skipRequireDependencies.contains(depends.getModuleName())) return "";
 
-        return new StringBuilder(OSGI_CAPABILITY_MODULE_DEPENDENCIES)
-                .append(";filter:=\"").append(depends.toFilterString()).append("\"").toString();
+        StringBuilder sb = new StringBuilder(OSGI_CAPABILITY_MODULE_DEPENDENCIES)
+                .append(";filter:=\"").append(depends.toFilterString()).append("\"");
+        if (depends.isOptional()) {
+            sb.append(";resolution:=\"optional\"");
+        }
+        return sb.toString();
     }
 
     public static String buildProvideCapabilities(String dependency, String version) {

--- a/maven-jahia-plugin/src/test/java/org/jahia/utils/maven/plugin/osgi/models/JahiaDependsTest.java
+++ b/maven-jahia-plugin/src/test/java/org/jahia/utils/maven/plugin/osgi/models/JahiaDependsTest.java
@@ -34,21 +34,65 @@ import static org.junit.Assert.*;
  */
 public class JahiaDependsTest {
 
-    public void testParser(String dependsStr, String moduleName, String min, String max, String filterString) {
+    public void testParser(String dependsStr, String moduleName, String min, String max, boolean isOptional, String filterString) {
         JahiaDepends depends = new JahiaDepends(dependsStr);
         assertEquals(moduleName, depends.getModuleName());
         assertEquals(min, depends.getMinVersion());
         assertEquals(max, depends.getMaxVersion());
         assertEquals(StringUtils.isNotEmpty(min) || StringUtils.isNotEmpty(max), depends.hasVersion());
         assertEquals(filterString, depends.toFilterString());
+        assertEquals(isOptional, depends.isOptional());
     }
 
     @Test
     public void testParser() {
-        testParser("module-name1", "module-name1", "", "", "(moduleIdentifier=module-name1)");
-        testParser("module-name1=[1.4, 2.0)", "module-name1", "1.4.0", "2.0.0",
+        testParser("module-name1=[1.4, 2.0)", "module-name1", "1.4.0", "2.0.0", false,
                 "(&(moduleIdentifier=module-name1)(moduleVersion>=1.4.0)(!(moduleVersion>=2.0.0)))");
-        testParser("module-name1=1.4", "module-name1", "1.4.0", Version.HIGHEST.toString(),
+        testParser("module-name1=1.4", "module-name1", "1.4.0", Version.HIGHEST.toString(), false,
+                "(&(moduleIdentifier=module-name1)(moduleVersion>=1.4.0))");
+    }
+
+    @Test
+    public void testModuleOnly() {
+        testParser("module-name1", "module-name1", "", "", false,
+                "(moduleIdentifier=module-name1)");
+    }
+
+    @Test
+    public void testRangedFilter() {
+        testParser("module-name1=[1.4, 2.0)", "module-name1", "1.4.0", "2.0.0", false,
+                "(&(moduleIdentifier=module-name1)(moduleVersion>=1.4.0)(!(moduleVersion>=2.0.0)))");
+    }
+
+    @Test
+    public void testMinFilter() {
+        testParser("module-name1=1.4", "module-name1", "1.4.0", Version.HIGHEST.toString(), false,
+                "(&(moduleIdentifier=module-name1)(moduleVersion>=1.4.0))");
+    }
+
+    @Test
+    public void testModuleOptional() {
+        testParser("module-name1=optional", "module-name1", "", "", true,
+                "(moduleIdentifier=module-name1)");
+    }
+
+    @Test
+    public void testRangedFilterOptional() {
+        testParser("module-name1=[1.4, 2.0);optional", "module-name1", "1.4.0", "2.0.0", true,
+                "(&(moduleIdentifier=module-name1)(moduleVersion>=1.4.0)(!(moduleVersion>=2.0.0)))");
+
+    }
+
+    /** optional keyword needs to be after version */
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidRangeFilterOptional() {
+        testParser("module-name1=optional;[1.4, 2.0)", "module-name1", "1.4.0", "2.0.0", true,
+                "(&(moduleIdentifier=module-name1)(moduleVersion>=1.4.0)(!(moduleVersion>=2.0.0)))");
+    }
+
+    @Test
+    public void testMinFilterOptional() {
+        testParser("module-name1=1.4;optional", "module-name1", "1.4.0", Version.HIGHEST.toString(), true,
                 "(&(moduleIdentifier=module-name1)(moduleVersion>=1.4.0))");
     }
 

--- a/maven-jahia-plugin/src/test/java/org/jahia/utils/maven/plugin/osgi/utils/CapabilityUtilsTest.java
+++ b/maven-jahia-plugin/src/test/java/org/jahia/utils/maven/plugin/osgi/utils/CapabilityUtilsTest.java
@@ -271,8 +271,14 @@ public class CapabilityUtilsTest {
             String jahiaDepends = "module-name1=2.5,module-name2=(2.5.4, 3], module-name3=[0,1.4), "
                     + "module with a space ,module-name5=[2,3.4.23]";
             String actual = CapabilityUtils.replaceDependsDelimiter(jahiaDepends);
-            assertEquals("module-name1=2.5;module-name2=(2.5.4, 3]; module-name3=[0,1.4); "
-                    + "module with a space ;module-name5=[2,3.4.23]", actual);
+            String expected = StringUtils.join(new String[] {
+                    "module-name1=2.5",
+                    "module-name2=(2.5.4, 3]",
+                    " module-name3=[0,1.4)",
+                    " module with a space ",
+                    "module-name5=[2,3.4.23]",
+            }, CapabilityUtils.DELIMITER);
+            assertEquals(expected, actual);
         } catch (Exception e) {
             fail("Unexpected exception: " + e.getMessage());
         }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-1057

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

* Add support for optional keyword in jahia-depends dependencies
  * parsing optional keyword in jahia-depends attribute
  * Add resolution:=optional tag when generating OSGI Require-Capability string
* Added unit tests