### PR TITLE
BACKLOG-20795: Update db drivers

### DIFF
--- a/configurators/pom.xml
+++ b/configurators/pom.xml
@@ -57,10 +57,10 @@
     <packaging>jar</packaging>
     <properties>
         <driver.derby.version>10.14.2.0</driver.derby.version>
-        <driver.mssql.version>9.2.1.jre8</driver.mssql.version>
-        <driver.mysql.version>8.0.32</driver.mysql.version>
-        <driver.oracle.version>21.1.0.0</driver.oracle.version>
-        <driver.postgresql.version>42.5.2</driver.postgresql.version>
+        <driver.mssql.version>9.4.1.jre8</driver.mssql.version>
+        <driver.mysql.version>8.0.33</driver.mysql.version>
+        <driver.oracle.version>21.9.0.0</driver.oracle.version>
+        <driver.postgresql.version>42.6.0</driver.postgresql.version>
         <driver.mariadb.version>3.0.9</driver.mariadb.version>
     </properties>
     <dependencies>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20795

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

- PostgreSQL to latest 42.6.0
- MySQL to latest 8.0.33
- Oracle to latest minor version 21.9.0.0 (latest major is 23.2.0)
- Mssql to latest 9.x minor stable verson 9.4.1.jre8 (latest major is 12.2.0.jre8)
  - I saw a renovate PR for this but was rejected. I'm assuming it's because of the jre16 classifer (https://github.com/Jahia/jahia-private/pull/1500 - to be verified)
  - Attempt to upgrade to 11 has been reverted here [QA-14573](https://jira.jahia.org/browse/QA-14573)
- Mariadb keep to current 3.0.9 version (latest minor is 3.0.10 and latest is 3.1.2 but both upgrades ran into issues - see [BACKLOG-20691](https://jira.jahia.org/browse/BACKLOG-20691))
- Derby keep to current 10.14.2.0 version (incompatible with latest version 10.16.1.1 - https://github.com/Jahia/jahia-private/pull/1501