### PR TITLE
QA-14911: upgrade bundle-plugin / bndlib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <jdom2.version>2.0.6</jdom2.version>
         <commons-io.version>2.11.0</commons-io.version>
         <bndlib.version>6.1.0</bndlib.version>
-        <maven.bundle.plugin.version>5.1.2</maven.bundle.plugin.version>
+        <maven.bundle.plugin.version>5.1.9</maven.bundle.plugin.version>
 	</properties>
 
     <modules>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14911

## Description

bundle-plugin 5.1.2 comes by default with bndlib 5, which creates invalid osgi-tools jar (could happen on other jars) - this jar cannot be opened by jdk 11.0.20 anymore because of https://www.oracle.com/java/technologies/javase/11-0-20-relnotes.html#JDK-8302483 (added more validation on zip64, probably due to a security issue). Upgrading to 5.1.9 goes to bndlib 6 and creates valid jars.
