### PR TITLE
BACKLOG-21153: update Mariadb driver

### DIFF
--- a/configurators/pom.xml
+++ b/configurators/pom.xml
@@ -62,7 +62,7 @@
         <driver.mysql.version>8.3.0</driver.mysql.version>
         <driver.oracle.version>21.13.0.0</driver.oracle.version>
         <driver.postgresql.version>42.6.1</driver.postgresql.version>
-        <driver.mariadb.version>3.0.9</driver.mariadb.version>
+        <driver.mariadb.version>3.3.3</driver.mariadb.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-21153

## Description

Update Mariadb driver version to 3.3.3 as issue with https://jira.jahia.org/browse/BACKLOG-22439 is fixed.