### PR TITLE
TECH-1416: Upgrade guava 

### DIFF
--- a/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/osgi/CheckDependenciesMojo.java
+++ b/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/osgi/CheckDependenciesMojo.java
@@ -51,8 +51,6 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
 import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.jar.JarArchiver;
@@ -62,7 +60,9 @@ import org.jahia.utils.osgi.ManifestValueClause;
 import org.jahia.utils.osgi.parsers.PackageInfo;
 import org.jahia.utils.osgi.parsers.ParsingContext;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.*;
 import java.util.jar.Manifest;
 import java.util.stream.Collectors;
@@ -113,7 +113,6 @@ public class CheckDependenciesMojo extends DependenciesMojo {
      * @component
      */
     private ArchiverManager archiverManager;
-
 
     @Override
     public void execute() throws MojoExecutionException {

--- a/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/osgi/CheckDependenciesMojo.java
+++ b/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/osgi/CheckDependenciesMojo.java
@@ -51,6 +51,8 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
 import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.jar.JarArchiver;
@@ -94,6 +96,12 @@ public class CheckDependenciesMojo extends DependenciesMojo {
      */
     protected boolean skipCheckDependencies;
     /**
+     * If the overwritten MANIFEST should be dumped in the target directory
+     *
+     * @parameter default-value="false" expression="${jahia.modules.dumpOverwrittenManifest}"
+     */
+    protected boolean dumpOverwrittenManifest;
+    /**
      * @component
      */
     private MavenProjectHelper mavenProjectHelper;
@@ -105,6 +113,7 @@ public class CheckDependenciesMojo extends DependenciesMojo {
      * @component
      */
     private ArchiverManager archiverManager;
+
 
     @Override
     public void execute() throws MojoExecutionException {
@@ -272,6 +281,17 @@ public class CheckDependenciesMojo extends DependenciesMojo {
             getLog().info("Overwriting existing META-INF/MANIFEST file");
         } else {
             getLog().warn("Missing META-INF/MANIFEST.MF file in bundle, how did that happen ?");
+        }
+
+        if (dumpOverwrittenManifest) {
+            File dumpManifestFile = new File(project.getBuild().getOutputDirectory(), "META-INF/MANIFEST.OVERWRITE.MF");
+            getLog().info("Dumping overwritten manifest file in: " + dumpManifestFile.getAbsolutePath());
+            try (FileOutputStream dumpManifestFileOutputStream = new FileOutputStream(dumpManifestFile)) {
+                manifest.write(dumpManifestFileOutputStream);
+            } catch (IOException e) {
+                getLog().error("Error writing dumped META-INF/MANIFEST.OVERWRITE.MF file", e);
+                return;
+            }
         }
 
         try (FileOutputStream manifestFileOutputStream = new FileOutputStream(manifestFile)) {


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/TECH-1416

## Description

During the guava migration it appears that some OSGI imports are overwritten by the jahia plugin directly in the JAR MANIFEST which make difficult to understand what happens. This juste create a dump of the generated MANIFEST inside the target directory aside the original one. It is also disable by default and configurable.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

I have considered the following implications of my change: 

- [X] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [X] Performance
- [X] Migration
- [X] Code maintainability
