### PR TITLE
BACKLOG-22482: Upgrade MSSQL driver to 12.6

### DIFF
--- a/configurators/pom.xml
+++ b/configurators/pom.xml
@@ -58,7 +58,7 @@
     <packaging>jar</packaging>
     <properties>
         <driver.derby.version>10.14.2.0</driver.derby.version>
-        <driver.mssql.version>9.4.1.jre11</driver.mssql.version>
+        <driver.mssql.version>12.6.1.jre11</driver.mssql.version>
         <driver.mysql.version>8.3.0</driver.mysql.version>
         <driver.oracle.version>21.13.0.0</driver.oracle.version>
         <driver.postgresql.version>42.6.1</driver.postgresql.version>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22482

## Description

According to https://learn.microsoft.com/en-us/sql/connect/jdbc/microsoft-jdbc-driver-for-sql-server-support-matrix?view=sql-server-ver16#sql-version-compatibility, version 12.6 of the driver is compatible SQL Server 2014 and 2022