### PR TITLE
TECH-1813: Create a dump of the overwritten MANIFEST

### DIFF
--- a/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/osgi/CheckDependenciesMojo.java
+++ b/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/osgi/CheckDependenciesMojo.java
@@ -274,6 +274,14 @@ public class CheckDependenciesMojo extends DependenciesMojo {
             getLog().warn("Missing META-INF/MANIFEST.MF file in bundle, how did that happen ?");
         }
 
+        File dumpManifestFile = new File(project.getBuild().getOutputDirectory(), "META-INF/MANIFEST.JAHIA.MF");
+        try (FileOutputStream dumpManifestFileOutputStream = new FileOutputStream(dumpManifestFile)) {
+            manifest.write(dumpManifestFileOutputStream);
+        } catch (IOException e) {
+            getLog().error("Error dumping new META-INF/MANIFEST.JAHIA.MF file", e);
+            return;
+        }
+
         try (FileOutputStream manifestFileOutputStream = new FileOutputStream(manifestFile)) {
             manifest.write(manifestFileOutputStream);
         } catch (IOException e) {


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/TECH-1813

## Description

Dump the jahia plugin MANIFEST overritten in the maven target folder.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

I have considered the following implications of my change: 

- [X] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [X] Performance
- [X] Migration
- [X] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
