### PR TITLE
feat: introduce new jahia maven plugin goal: generate-vendored-js-bom

### DIFF
--- a/maven-jahia-plugin/pom.xml
+++ b/maven-jahia-plugin/pom.xml
@@ -312,6 +312,10 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-yaml</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>

--- a/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/BomModel.java
+++ b/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/BomModel.java
@@ -45,19 +45,32 @@ package org.jahia.utils.maven.plugin.sbom;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 /**
  * CycloneDX 1.4 BOM model.
  */
 public class BomModel {
+    private String bomFormat = "CycloneDX";
     private String bomVersion;
     private String specVersion;
     private int version;
     private List<ComponentModel> components;
-
+    
+    public String getBomFormat() {
+        return bomFormat;
+    }
+    
+    public void setBomFormat(String bomFormat) {
+        this.bomFormat = bomFormat;
+    }
+    
+    @JsonIgnore
     public String getBomVersion() {
         return bomVersion;
     }
-
+    
+    @JsonIgnore
     public void setBomVersion(String bomVersion) {
         this.bomVersion = bomVersion;
     }

--- a/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/BomModel.java
+++ b/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/BomModel.java
@@ -1,0 +1,88 @@
+/*
+ * ==========================================================================================
+ * =                   JAHIA'S DUAL LICENSING - IMPORTANT INFORMATION                       =
+ * ==========================================================================================
+ *
+ *                                 http://www.jahia.com
+ *
+ *     Copyright (C) 2002-2026 Jahia Solutions Group SA. All rights reserved.
+ *
+ *     THIS FILE IS AVAILABLE UNDER TWO DIFFERENT LICENSES:
+ *     1/GPL OR 2/JSEL
+ *
+ *     1/ GPL
+ *     ==================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE GPL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ *     2/ JSEL - Commercial and Supported Versions of the program
+ *     ===================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     Alternatively, commercial and supported versions of the program - also known as
+ *     Enterprise Distributions - must be used in accordance with the terms and conditions
+ *     contained in a separate written agreement between you and Jahia Solutions Group SA.
+ *
+ *     If you are unsure which license is appropriate for your use,
+ *     please contact the sales department at sales@jahia.com.
+ */
+package org.jahia.utils.maven.plugin.sbom;
+
+import java.util.List;
+
+/**
+ * CycloneDX 1.4 BOM model.
+ */
+public class BomModel {
+    private String bomVersion;
+    private String specVersion;
+    private int version;
+    private List<ComponentModel> components;
+
+    public String getBomVersion() {
+        return bomVersion;
+    }
+
+    public void setBomVersion(String bomVersion) {
+        this.bomVersion = bomVersion;
+    }
+
+    public String getSpecVersion() {
+        return specVersion;
+    }
+
+    public void setSpecVersion(String specVersion) {
+        this.specVersion = specVersion;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public List<ComponentModel> getComponents() {
+        return components;
+    }
+
+    public void setComponents(List<ComponentModel> components) {
+        this.components = components;
+    }
+}

--- a/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/BomSerializer.java
+++ b/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/BomSerializer.java
@@ -1,0 +1,65 @@
+/*
+ * ==========================================================================================
+ * =                   JAHIA'S DUAL LICENSING - IMPORTANT INFORMATION                       =
+ * ==========================================================================================
+ *
+ *                                 http://www.jahia.com
+ *
+ *     Copyright (C) 2002-2026 Jahia Solutions Group SA. All rights reserved.
+ *
+ *     THIS FILE IS AVAILABLE UNDER TWO DIFFERENT LICENSES:
+ *     1/GPL OR 2/JSEL
+ *
+ *     1/ GPL
+ *     ==================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE GPL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ *     2/ JSEL - Commercial and Supported Versions of the program
+ *     ===================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     Alternatively, commercial and supported versions of the program - also known as
+ *     Enterprise Distributions - must be used in accordance with the terms and conditions
+ *     contained in a separate written agreement between you and Jahia Solutions Group SA.
+ *
+ *     If you are unsure which license is appropriate for your use,
+ *     please contact the sales department at sales@jahia.com.
+ */
+package org.jahia.utils.maven.plugin.sbom;
+
+import java.io.Writer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+/**
+ * Serializer for BOM models to JSON format.
+ */
+public class BomSerializer {
+    
+    private BomSerializer() {
+        // Utility class, no instantiation needed
+    }
+
+    public static void serializeToJson(BomModel bom, Writer writer) throws java.io.IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        mapper.writeValue(writer, bom);
+    }
+}

--- a/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/BomSerializer.java
+++ b/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/BomSerializer.java
@@ -45,6 +45,7 @@ package org.jahia.utils.maven.plugin.sbom;
 
 import java.io.Writer;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
@@ -59,6 +60,7 @@ public class BomSerializer {
 
     public static void serializeToJson(BomModel bom, Writer writer) throws java.io.IOException {
         ObjectMapper mapper = new ObjectMapper();
+        mapper.setSerializationInclusion(Include.NON_NULL);
         mapper.enable(SerializationFeature.INDENT_OUTPUT);
         mapper.writeValue(writer, bom);
     }

--- a/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/ComponentModel.java
+++ b/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/ComponentModel.java
@@ -1,0 +1,235 @@
+/*
+ * ==========================================================================================
+ * =                   JAHIA'S DUAL LICENSING - IMPORTANT INFORMATION                       =
+ * ==========================================================================================
+ *
+ *                                 http://www.jahia.com
+ *
+ *     Copyright (C) 2002-2026 Jahia Solutions Group SA. All rights reserved.
+ *
+ *     THIS FILE IS AVAILABLE UNDER TWO DIFFERENT LICENSES:
+ *     1/GPL OR 2/JSEL
+ *
+ *     1/ GPL
+ *     ==================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE GPL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ *     2/ JSEL - Commercial and Supported Versions of the program
+ *     ===================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     Alternatively, commercial and supported versions of the program - also known as
+ *     Enterprise Distributions - must be used in accordance with the terms and conditions
+ *     contained in a separate written agreement between you and Jahia Solutions Group SA.
+ *
+ *     If you are unsure which license is appropriate for your use,
+ *     please contact the sales department at sales@jahia.com.
+ */
+package org.jahia.utils.maven.plugin.sbom;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * CycloneDX 1.4 Component model.
+ */
+public class ComponentModel {
+    /**
+     * CycloneDX OrganizationalEntity — serializes as {"name": "..."}.
+     */
+    public static class OrganizationalEntity {
+        private String name;
+
+        public OrganizationalEntity(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    private String type;
+    private String name;
+    private String version;
+    private String purl;
+    /**
+     * CycloneDX LicenseChoice — serializes as {"license": {"id": "..."}}
+     * or {"expression": "..."} for compound expressions.
+     */
+    public static class LicenseChoice {
+        private LicenseEntry license;
+
+        public LicenseChoice(String spdxId) {
+            this.license = new LicenseEntry(spdxId);
+        }
+
+        public LicenseEntry getLicense() {
+            return license;
+        }
+
+        public void setLicense(LicenseEntry license) {
+            this.license = license;
+        }
+    }
+
+    public static class LicenseEntry {
+        private String id;
+
+        public LicenseEntry(String id) {
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+    }
+
+    private OrganizationalEntity supplier;
+    private String copyright;
+    private List<LicenseChoice> licenses;
+    private List<Map<String, String>> hashes;
+    private List<Property> properties;
+    private String description;
+
+    /**
+     * CycloneDX Property — serializes as {"name": "...", "value": "..."}.
+     */
+    public static class Property {
+        private String name;
+        private String value;
+
+        public Property(String name, String value) {
+            this.name = name;
+            this.value = value;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getPurl() {
+        return purl;
+    }
+
+    public void setPurl(String purl) {
+        this.purl = purl;
+    }
+
+    public OrganizationalEntity getSupplier() {
+        return supplier;
+    }
+
+    public void setSupplier(OrganizationalEntity supplier) {
+        this.supplier = supplier;
+    }
+
+    public String getCopyright() {
+        return copyright;
+    }
+
+    public void setCopyright(String copyright) {
+        this.copyright = copyright;
+    }
+
+    public List<LicenseChoice> getLicenses() {
+        return licenses;
+    }
+
+    public void setLicenses(List<LicenseChoice> licenses) {
+        this.licenses = licenses;
+    }
+
+    public List<Map<String, String>> getHashes() {
+        return hashes;
+    }
+
+    public void setHashes(List<Map<String, String>> hashes) {
+        this.hashes = hashes;
+    }
+
+    public void addHash(Map<String, String> hash) {
+        if (hashes == null) {
+            hashes = new ArrayList<>();
+        }
+        hashes.add(hash);
+    }
+
+    public List<Property> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(List<Property> properties) {
+        this.properties = properties;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/ComponentModel.java
+++ b/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/ComponentModel.java
@@ -47,6 +47,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 /**
  * CycloneDX 1.4 Component model.
  */
@@ -186,10 +188,12 @@ public class ComponentModel {
         this.supplier = supplier;
     }
 
+    @JsonIgnore
     public String getCopyright() {
         return copyright;
     }
 
+    @JsonIgnore
     public void setCopyright(String copyright) {
         this.copyright = copyright;
     }

--- a/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/GenerateVendoredJsBomMojo.java
+++ b/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/GenerateVendoredJsBomMojo.java
@@ -1,0 +1,259 @@
+/*
+ * ==========================================================================================
+ * =                   JAHIA'S DUAL LICENSING - IMPORTANT INFORMATION                       =
+ * ==========================================================================================
+ *
+ *                                 http://www.jahia.com
+ *
+ *     Copyright (C) 2002-2026 Jahia Solutions Group SA. All rights reserved.
+ *
+ *     THIS FILE IS AVAILABLE UNDER TWO DIFFERENT LICENSES:
+ *     1/GPL OR 2/JSEL
+ *
+ *     1/ GPL
+ *     ==================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE GPL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ *     2/ JSEL - Commercial and Supported Versions of the program
+ *     ===================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     Alternatively, commercial and supported versions of the program - also known as
+ *     Enterprises Distribution - must be used in accordance with the terms and conditions
+ *     contained in a separate written agreement between you and Jahia Solutions Group SA.
+ *
+ *     If you are unsure which license is appropriate for your use,
+ *     please contact the sales department at sales@jahia.com.
+ */
+package org.jahia.utils.maven.plugin.sbom;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.codec.binary.Hex;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+
+/**
+ * Generates a CycloneDX 1.4 Software Bill of Materials (SBOM) for manually packaged JavaScript libraries
+ * (vendored JavaScript files). Reads from a vendored-js.yaml manifest and outputs a JSON BOM suitable
+ * for merging with Maven and Webpack-generated BOMs before uploading to Dependency-Track.
+ *
+ * @goal generate-vendored-js-bom
+ * @phase process-resources
+ * @requiresProject true
+ */
+public class GenerateVendoredJsBomMojo extends AbstractMojo {
+
+    /**
+     * The path to the vendored JavaScript manifest file (YAML).
+     * Relative to project basedir.
+     *
+     * @parameter default-value="vendored-js.yaml"
+     */
+    private String manifestFile;
+
+    /**
+     * The output directory for the generated BOM file.
+     *
+     * @parameter expression="${project.build.directory}"
+     * @required
+     */
+    private File outputDirectory;
+
+    /**
+     * The name of the output BOM file (without extension).
+     *
+     * @parameter default-value="vendored-js-bom.cdx"
+     */
+    private String outputFileName;
+
+    /**
+     * Project base directory.
+     *
+     * @parameter expression="${project.basedir}"
+     * @required
+     */
+    private File basedir;
+
+    /**
+     * Skip execution if manifest file does not exist.
+     *
+     * @parameter default-value="true"
+     */
+    private boolean skipIfMissing;
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        File manifest = new File(basedir, manifestFile);
+
+        if (!manifest.exists()) {
+            if (skipIfMissing) {
+                getLog().info("Vendored JS manifest not found at " + manifest.getAbsolutePath() + "; skipping BOM generation.");
+                return;
+            } else {
+                throw new MojoFailureException("Vendored JS manifest not found at " + manifest.getAbsolutePath());
+            }
+        }
+
+        try {
+            getLog().info("Loading vendored JavaScript manifest from " + manifest.getAbsolutePath());
+            VendoredJsManifest parsedManifest = VendoredJsManifestParser.parse(manifest);
+
+            getLog().info("Generating CycloneDX 1.4 SBOM from " + parsedManifest.getComponents().size() + " component(s)");
+            BomModel bom = generateBom(parsedManifest);
+
+            if (!outputDirectory.exists()) {
+                outputDirectory.mkdirs();
+            }
+
+            File outputFile = new File(outputDirectory, outputFileName + ".json");
+            try (OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(outputFile), StandardCharsets.UTF_8)) {
+                BomSerializer.serializeToJson(bom, writer);
+            }
+
+            getLog().info("Vendored JS BOM written to " + outputFile.getAbsolutePath());
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to generate vendored JS BOM: " + e.getMessage(), e);
+        }
+    }
+
+    private BomModel generateBom(VendoredJsManifest manifest) throws IOException {
+        BomModel bom = new BomModel();
+        bom.setBomVersion("1");
+        bom.setSpecVersion("1.4");
+        bom.setVersion(1);
+
+        List<ComponentModel> components = new ArrayList<>();
+        for (VendoredJsComponent componentDef : manifest.getComponents()) {
+            components.add(buildComponent(componentDef));
+        }
+
+        bom.setComponents(components);
+        return bom;
+    }
+
+    private ComponentModel buildComponent(VendoredJsComponent componentDef) throws IOException {
+        ComponentModel component = new ComponentModel();
+
+        setBasicProperties(component, componentDef);
+        addPurl(component, componentDef);
+        addLicenses(component, componentDef);
+        addHashes(component, componentDef);
+        addSupplier(component, componentDef);
+        addCopyright(component, componentDef);
+        addProperties(component, componentDef);
+        addDescription(component, componentDef);
+
+        return component;
+    }
+
+    private void setBasicProperties(ComponentModel component, VendoredJsComponent componentDef) {
+        String componentType = componentDef.getType();
+        component.setType(componentType != null ? componentType : "library");
+        component.setName(componentDef.getName());
+        component.setVersion(componentDef.getVersion());
+    }
+
+    private void addPurl(ComponentModel component, VendoredJsComponent componentDef) {
+        if (componentDef.getPurl() != null) {
+            component.setPurl(componentDef.getPurl());
+        }
+    }
+
+    private void addLicenses(ComponentModel component, VendoredJsComponent componentDef) {
+        if (componentDef.getLicenses() != null && !componentDef.getLicenses().isEmpty()) {
+            List<ComponentModel.LicenseChoice> licenseChoices = new ArrayList<>();
+            for (String licenseId : componentDef.getLicenses()) {
+                licenseChoices.add(new ComponentModel.LicenseChoice(licenseId));
+            }
+            component.setLicenses(licenseChoices);
+        }
+    }
+
+    private void addHashes(ComponentModel component, VendoredJsComponent componentDef) throws IOException {
+        if (componentDef.getFiles() != null && !componentDef.getFiles().isEmpty()) {
+            for (String filePath : componentDef.getFiles()) {
+                File file = new File(basedir, filePath);
+                if (file.exists() && file.isFile()) {
+                    String sha256 = computeSha256(file);
+                    Map<String, String> hash = new HashMap<>();
+                    hash.put("alg", "SHA-256");
+                    hash.put("content", sha256);
+                    component.addHash(hash);
+                }
+            }
+        }
+    }
+
+    private void addSupplier(ComponentModel component, VendoredJsComponent componentDef) {
+        if (componentDef.getSupplier() != null) {
+            component.setSupplier(new ComponentModel.OrganizationalEntity(componentDef.getSupplier()));
+        }
+    }
+
+    private void addCopyright(ComponentModel component, VendoredJsComponent componentDef) {
+        if (componentDef.getCopyright() != null) {
+            component.setCopyright(componentDef.getCopyright());
+        }
+    }
+
+    private void addProperties(ComponentModel component, VendoredJsComponent componentDef) {
+        List<ComponentModel.Property> properties = new ArrayList<>();
+        if (componentDef.getFiles() != null && !componentDef.getFiles().isEmpty()) {
+            properties.add(new ComponentModel.Property("jahia:source-paths", String.join(",", componentDef.getFiles())));
+        }
+        if (componentDef.isModified()) {
+            properties.add(new ComponentModel.Property("jahia:modified", "true"));
+        }
+        properties.add(new ComponentModel.Property("jahia:component-source", "vendored-javascript"));
+        component.setProperties(properties);
+    }
+
+    private void addDescription(ComponentModel component, VendoredJsComponent componentDef) {
+        if (componentDef.getNotes() != null) {
+            component.setDescription(componentDef.getNotes());
+        }
+    }
+
+    private String computeSha256(File file) throws IOException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            try (FileInputStream fis = new FileInputStream(file)) {
+                byte[] buffer = new byte[8192];
+                int bytesRead;
+                while ((bytesRead = fis.read(buffer)) != -1) {
+                    digest.update(buffer, 0, bytesRead);
+                }
+            }
+            return Hex.encodeHexString(digest.digest());
+        } catch (Exception e) {
+            throw new IOException("Failed to compute SHA-256 for " + file.getAbsolutePath(), e);
+        }
+    }
+}

--- a/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/GenerateVendoredJsBomMojo.java
+++ b/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/GenerateVendoredJsBomMojo.java
@@ -229,25 +229,11 @@ public class GenerateVendoredJsBomMojo extends AbstractMojo {
             return;
         }
 
-        if (resolved.isDirectory()) {
-            processDirectory(component, resolvedPath);
-        } else if (resolved.isFile()) {
+        if (resolved.isFile()) {
             processFile(component, resolved);
         }
     }
 
-    private void processDirectory(ComponentModel component, Path dirPath) throws IOException {
-        try (Stream<Path> stream = Files.walk(dirPath)) {
-            stream.filter(p -> Files.isRegularFile(p) && p.getFileName().toString().endsWith(".js"))
-                  .forEach(p -> {
-                      try {
-                          addHashToComponent(component, p.toFile());
-                      } catch (IOException e) {
-                          getLog().warn("Failed to compute hash for: " + p, e);
-                      }
-                  });
-        }
-    }
 
     private void processFile(ComponentModel component, File file) throws IOException {
         addHashToComponent(component, file);

--- a/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/GenerateVendoredJsBomMojo.java
+++ b/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/GenerateVendoredJsBomMojo.java
@@ -48,12 +48,15 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.io.IOException;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.apache.commons.codec.binary.Hex;
 import org.apache.maven.plugin.AbstractMojo;
@@ -70,6 +73,8 @@ import org.apache.maven.plugin.MojoFailureException;
  * @requiresProject true
  */
 public class GenerateVendoredJsBomMojo extends AbstractMojo {
+    
+    private static final String SHA256_ALGORITHM = "SHA-256";
 
     /**
      * The path to the vendored JavaScript manifest file (YAML).
@@ -197,18 +202,63 @@ public class GenerateVendoredJsBomMojo extends AbstractMojo {
     }
 
     private void addHashes(ComponentModel component, VendoredJsComponent componentDef) throws IOException {
-        if (componentDef.getFiles() != null && !componentDef.getFiles().isEmpty()) {
-            for (String filePath : componentDef.getFiles()) {
-                File file = new File(basedir, filePath);
-                if (file.exists() && file.isFile()) {
-                    String sha256 = computeSha256(file);
-                    Map<String, String> hash = new HashMap<>();
-                    hash.put("alg", "SHA-256");
-                    hash.put("content", sha256);
-                    component.addHash(hash);
-                }
-            }
+        if (componentDef.getFiles() == null || componentDef.getFiles().isEmpty()) {
+            return;
         }
+
+        Path basePath = basedir.getCanonicalFile().toPath();
+        for (String filePath : componentDef.getFiles()) {
+            processFilePath(component, filePath, basePath);
+        }
+    }
+
+    private void processFilePath(ComponentModel component, String filePath, Path basePath) throws IOException {
+        if (filePath == null || filePath.trim().isEmpty()) {
+            return;
+        }
+
+        File resolved = new File(basedir, filePath).getCanonicalFile();
+        Path resolvedPath = resolved.toPath();
+
+        if (!resolvedPath.startsWith(basePath)) {
+            throw new IOException("Manifest path escapes project basedir: " + filePath);
+        }
+
+        if (!resolved.exists()) {
+            getLog().warn("Manifest path not found; skipping hash computation: " + filePath);
+            return;
+        }
+
+        if (resolved.isDirectory()) {
+            processDirectory(component, resolvedPath);
+        } else if (resolved.isFile()) {
+            processFile(component, resolved);
+        }
+    }
+
+    private void processDirectory(ComponentModel component, Path dirPath) throws IOException {
+        try (Stream<Path> stream = Files.walk(dirPath)) {
+            stream.filter(p -> Files.isRegularFile(p) && p.getFileName().toString().endsWith(".js"))
+                  .forEach(p -> {
+                      try {
+                          addHashToComponent(component, p.toFile());
+                      } catch (IOException e) {
+                          getLog().warn("Failed to compute hash for: " + p, e);
+                      }
+                  });
+        }
+    }
+
+    private void processFile(ComponentModel component, File file) throws IOException {
+        addHashToComponent(component, file);
+    }
+
+    private void addHashToComponent(ComponentModel component, File file) throws IOException {
+        String sha256 = computeSha256(file);
+        Map<String, String> hash = new HashMap<>();
+        hash.put("alg", SHA256_ALGORITHM);
+        hash.put("content", sha256);
+        component.addHash(hash);
     }
 
     private void addSupplier(ComponentModel component, VendoredJsComponent componentDef) {
@@ -243,7 +293,7 @@ public class GenerateVendoredJsBomMojo extends AbstractMojo {
 
     private String computeSha256(File file) throws IOException {
         try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            MessageDigest digest = MessageDigest.getInstance(SHA256_ALGORITHM);
             try (FileInputStream fis = new FileInputStream(file)) {
                 byte[] buffer = new byte[8192];
                 int bytesRead;

--- a/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/ValidateVendoredJsManifestMojo.java
+++ b/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/ValidateVendoredJsManifestMojo.java
@@ -249,7 +249,11 @@ public class ValidateVendoredJsManifestMojo extends AbstractMojo {
             normalized = normalized.substring(1);
         }
 
-        // Case-insensitive matching on Windows.
-        return normalized.toLowerCase(Locale.ROOT);
+        // Case-insensitive matching on Windows only.
+        String osName = System.getProperty("os.name");
+        if (osName != null && osName.toLowerCase(Locale.ROOT).contains("win")) {
+            normalized = normalized.toLowerCase(Locale.ROOT);
+        }
+        return normalized;
     }
 }

--- a/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/ValidateVendoredJsManifestMojo.java
+++ b/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/ValidateVendoredJsManifestMojo.java
@@ -1,0 +1,255 @@
+/*
+ * ==========================================================================================
+ * =                   JAHIA'S DUAL LICENSING - IMPORTANT INFORMATION                       =
+ * ==========================================================================================
+ *
+ *                                 http://www.jahia.com
+ *
+ *     Copyright (C) 2002-2026 Jahia Solutions Group SA. All rights reserved.
+ *
+ *     THIS FILE IS AVAILABLE UNDER TWO DIFFERENT LICENSES:
+ *     1/GPL OR 2/JSEL
+ *
+ *     1/ GPL
+ *     ==================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE GPL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ *     2/ JSEL - Commercial and Supported Versions of the program
+ *     ===================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     Alternatively, commercial and supported versions of the program - also known as
+ *     Enterprise Distributions - must be used in accordance with the terms and conditions
+ *     contained in a separate written agreement between you and Jahia Solutions Group SA.
+ *
+ *     If you are unsure which license is appropriate for your use,
+ *     please contact the sales department at sales@jahia.com.
+ */
+package org.jahia.utils.maven.plugin.sbom;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+
+/**
+ * Validates that all manually packaged JavaScript files are represented in the
+ * vendored-js.yaml manifest. Scans configured resource directories and fails if
+ * unreferenced .js files are found (unless explicitly excluded).
+ *
+ * @goal validate-vendored-js-manifest
+ * @phase validate
+ * @requiresProject true
+ */
+public class ValidateVendoredJsManifestMojo extends AbstractMojo {
+
+    /**
+     * Comma-separated list of directory paths (relative to basedir) to scan
+     * for vendored JavaScript files. Example: assets/src/main/resources/javascript,default/src/main/resources/javascript
+     *
+     * @parameter default-value="src/main/resources/javascript"
+     */
+    private String vendoredJsDirectories;
+
+    /**
+     * Comma-separated list of file patterns to exclude from validation
+     * (e.g., min.js for minified files already covered by non-min versions).
+     *
+     * @parameter default-value=""
+     */
+    private String excludePatterns;
+
+    /**
+     * Skip validation if no vendored-js.yaml manifest exists.
+     *
+     * @parameter default-value="true"
+     */
+    private boolean skipIfNoManifest;
+
+    /**
+     * Project base directory.
+     *
+     * @parameter expression="${project.basedir}"
+     * @required
+     */
+    private File basedir;
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        File manifest = new File(basedir, "vendored-js.yaml");
+        if (!manifest.exists()) {
+            handleMissingManifest(manifest);
+            return;
+        }
+
+        try {
+            VendoredJsManifest parsed = VendoredJsManifestParser.parse(manifest);
+            ManifestData manifestData = extractManifestData(parsed);
+
+            getLog().info("Validating vendored JavaScript files against manifest (" + manifestData.files.size() + " files and "
+                    + manifestData.directories.size() + " directory references listed)");
+
+            List<String> unreferenced = scanDirectoriesForUnreferencedFiles(manifestData);
+
+            if (!unreferenced.isEmpty()) {
+                reportUnreferencedFiles(unreferenced);
+                throw new MojoFailureException(
+                        "Unreferenced vendored JavaScript files found. Update vendored-js.yaml to include all files.");
+            }
+
+            getLog().info("Vendored JavaScript manifest validation passed.");
+        } catch (java.io.IOException e) {
+            throw new MojoExecutionException("Failed to validate vendored JS manifest: " + e.getMessage(), e);
+        }
+    }
+
+    private void handleMissingManifest(File manifest) throws MojoFailureException {
+        if (skipIfNoManifest) {
+            getLog().debug("No vendored-js.yaml manifest found; skipping validation.");
+        } else {
+            throw new MojoFailureException("vendored-js.yaml manifest not found at " + manifest.getAbsolutePath());
+        }
+    }
+
+    private ManifestData extractManifestData(VendoredJsManifest parsed) {
+        ManifestData data = new ManifestData();
+        for (VendoredJsComponent component : parsed.getComponents()) {
+            if (component.getFiles() != null) {
+                for (String rawPath : component.getFiles()) {
+                    if (rawPath == null || rawPath.trim().isEmpty()) {
+                        continue;
+                    }
+                    classifyManifestPath(rawPath, data);
+                }
+            }
+        }
+        return data;
+    }
+
+    private void classifyManifestPath(String rawPath, ManifestData data) {
+        String normalizedPath = normalizePath(rawPath);
+        File pathFile = new File(basedir, rawPath);
+        boolean isDirectoryReference = normalizedPath.endsWith("/") || pathFile.isDirectory();
+
+        if (isDirectoryReference) {
+            data.directories.add(normalizedPath.endsWith("/") ? normalizedPath : normalizedPath + "/");
+        } else {
+            data.files.add(normalizedPath);
+        }
+    }
+
+    private List<String> scanDirectoriesForUnreferencedFiles(ManifestData manifestData) {
+        List<String> unreferenced = new ArrayList<>();
+        String[] directories = vendoredJsDirectories.split(",");
+
+        for (String dir : directories) {
+            dir = dir.trim();
+            File vendoredDir = new File(basedir, dir);
+            if (vendoredDir.exists() && vendoredDir.isDirectory()) {
+                scanForUnreferencedFiles(vendoredDir, vendoredDir, manifestData.files, manifestData.directories, unreferenced);
+            }
+        }
+
+        return unreferenced;
+    }
+
+    private void reportUnreferencedFiles(List<String> unreferenced) {
+        getLog().error("Found " + unreferenced.size() + " unreferenced vendored JavaScript file(s):");
+        for (String file : unreferenced) {
+            getLog().error("  - " + file);
+        }
+    }
+
+    private static class ManifestData {
+        List<String> files = new ArrayList<>();
+        List<String> directories = new ArrayList<>();
+    }
+
+    private void scanForUnreferencedFiles(File scanRoot, File dir, List<String> manifestedFiles,
+            List<String> manifestedDirectories, List<String> unreferenced) {
+        File[] files = dir.listFiles();
+        if (files == null) {
+            return;
+        }
+        for (File file : files) {
+            if (file.isDirectory()) {
+                scanForUnreferencedFiles(scanRoot, file, manifestedFiles, manifestedDirectories, unreferenced);
+            } else if (file.isFile() && file.getName().endsWith(".js")) {
+                String basedirRelativePath = normalizePath(basedir.toPath().relativize(file.toPath()).toString());
+                String scanRootRelativePath = normalizePath(scanRoot.toPath().relativize(file.toPath()).toString());
+
+                if (!isExcluded(basedirRelativePath)
+                        && !isExcluded(scanRootRelativePath)
+                        && !isManifested(basedirRelativePath, scanRootRelativePath, manifestedFiles, manifestedDirectories)) {
+                    unreferenced.add(file.getAbsolutePath());
+                }
+            }
+        }
+    }
+
+    private boolean isManifested(String basedirRelativePath, String scanRootRelativePath,
+            List<String> manifestedFiles, List<String> manifestedDirectories) {
+        if (manifestedFiles.contains(basedirRelativePath) || manifestedFiles.contains(scanRootRelativePath)) {
+            return true;
+        }
+
+        for (String directory : manifestedDirectories) {
+            if (basedirRelativePath.startsWith(directory) || scanRootRelativePath.startsWith(directory)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean isExcluded(String filePath) {
+        if (excludePatterns == null || excludePatterns.trim().isEmpty()) {
+            return false;
+        }
+        String normalizedFilePath = normalizePath(filePath);
+        String[] patterns = excludePatterns.split(",");
+        for (String pattern : patterns) {
+            String normalizedPattern = normalizePath(pattern.trim());
+            if (!normalizedPattern.isEmpty() && normalizedFilePath.contains(normalizedPattern)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String normalizePath(String path) {
+        if (path == null) {
+            return "";
+        }
+
+        String normalized = path.trim().replace('\\', '/');
+        while (normalized.startsWith("./")) {
+            normalized = normalized.substring(2);
+        }
+        if (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+
+        // Case-insensitive matching on Windows.
+        return normalized.toLowerCase(Locale.ROOT);
+    }
+}

--- a/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/VendoredJsComponent.java
+++ b/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/VendoredJsComponent.java
@@ -1,0 +1,146 @@
+/*
+ * ==========================================================================================
+ * =                   JAHIA'S DUAL LICENSING - IMPORTANT INFORMATION                       =
+ * ==========================================================================================
+ *
+ *                                 http://www.jahia.com
+ *
+ *     Copyright (C) 2002-2026 Jahia Solutions Group SA. All rights reserved.
+ *
+ *     THIS FILE IS AVAILABLE UNDER TWO DIFFERENT LICENSES:
+ *     1/GPL OR 2/JSEL
+ *
+ *     1/ GPL
+ *     ==================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE GPL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ *     2/ JSEL - Commercial and Supported Versions of the program
+ *     ===================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     Alternatively, commercial and supported versions of the program - also known as
+ *     Enterprise Distributions - must be used in accordance with the terms and conditions
+ *     contained in a separate written agreement between you and Jahia Solutions Group SA.
+ *
+ *     If you are unsure which license is appropriate for your use,
+ *     please contact the sales department at sales@jahia.com.
+ */
+package org.jahia.utils.maven.plugin.sbom;
+
+import java.util.List;
+
+/**
+ * Represents a single vendored JavaScript component from the manifest.
+ */
+public class VendoredJsComponent {
+    private String type;
+    private String name;
+    private String version;
+    private String purl;
+    private String supplier;
+    private String copyright;
+    private List<String> licenses;
+    private List<String> files;
+    private boolean modified;
+    private String notes;
+
+    public VendoredJsComponent() {
+        this.modified = false;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getPurl() {
+        return purl;
+    }
+
+    public void setPurl(String purl) {
+        this.purl = purl;
+    }
+
+    public String getSupplier() {
+        return supplier;
+    }
+
+    public void setSupplier(String supplier) {
+        this.supplier = supplier;
+    }
+
+    public String getCopyright() {
+        return copyright;
+    }
+
+    public void setCopyright(String copyright) {
+        this.copyright = copyright;
+    }
+
+    public List<String> getLicenses() {
+        return licenses;
+    }
+
+    public void setLicenses(List<String> licenses) {
+        this.licenses = licenses;
+    }
+
+    public List<String> getFiles() {
+        return files;
+    }
+
+    public void setFiles(List<String> files) {
+        this.files = files;
+    }
+
+    public boolean isModified() {
+        return modified;
+    }
+
+    public void setModified(boolean modified) {
+        this.modified = modified;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+}

--- a/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/VendoredJsManifest.java
+++ b/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/VendoredJsManifest.java
@@ -1,0 +1,68 @@
+/*
+ * ==========================================================================================
+ * =                   JAHIA'S DUAL LICENSING - IMPORTANT INFORMATION                       =
+ * ==========================================================================================
+ *
+ *                                 http://www.jahia.com
+ *
+ *     Copyright (C) 2002-2026 Jahia Solutions Group SA. All rights reserved.
+ *
+ *     THIS FILE IS AVAILABLE UNDER TWO DIFFERENT LICENSES:
+ *     1/GPL OR 2/JSEL
+ *
+ *     1/ GPL
+ *     ==================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE GPL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ *     2/ JSEL - Commercial and Supported Versions of the program
+ *     ===================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     Alternatively, commercial and supported versions of the program - also known as
+ *     Enterprise Distributions - must be used in accordance with the terms and conditions
+ *     contained in a separate written agreement between you and Jahia Solutions Group SA.
+ *
+ *     If you are unsure which license is appropriate for your use,
+ *     please contact the sales department at sales@jahia.com.
+ */
+package org.jahia.utils.maven.plugin.sbom;
+
+import java.util.List;
+
+/**
+ * Model for parsed vendored JavaScript manifest.
+ */
+public class VendoredJsManifest {
+    private List<VendoredJsComponent> components;
+
+    public VendoredJsManifest() {
+    }
+
+    public VendoredJsManifest(List<VendoredJsComponent> components) {
+        this.components = components;
+    }
+
+    public List<VendoredJsComponent> getComponents() {
+        return components;
+    }
+
+    public void setComponents(List<VendoredJsComponent> components) {
+        this.components = components;
+    }
+}

--- a/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/VendoredJsManifestParser.java
+++ b/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/VendoredJsManifestParser.java
@@ -1,0 +1,129 @@
+/*
+ * ==========================================================================================
+ * =                   JAHIA'S DUAL LICENSING - IMPORTANT INFORMATION                       =
+ * ==========================================================================================
+ *
+ *                                 http://www.jahia.com
+ *
+ *     Copyright (C) 2002-2026 Jahia Solutions Group SA. All rights reserved.
+ *
+ *     THIS FILE IS AVAILABLE UNDER TWO DIFFERENT LICENSES:
+ *     1/GPL OR 2/JSEL
+ *
+ *     1/ GPL
+ *     ==================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE GPL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ *     2/ JSEL - Commercial and Supported Versions of the program
+ *     ===================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     Alternatively, commercial and supported versions of the program - also known as
+ *     Enterprise Distributions - must be used in accordance with the terms and conditions
+ *     contained in a separate written agreement between you and Jahia Solutions Group SA.
+ *
+ *     If you are unsure which license is appropriate for your use,
+ *     please contact the sales department at sales@jahia.com.
+ */
+package org.jahia.utils.maven.plugin.sbom;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+/**
+ * Parser for vendored-js.yaml manifest files.
+ */
+public class VendoredJsManifestParser {
+
+    private VendoredJsManifestParser() {
+        // Utility class, no instantiation needed
+    }
+    
+    public static VendoredJsManifest parse(File manifestFile) throws IOException {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        Map<String, Object> data = mapper.readValue(new FileInputStream(manifestFile), new TypeReference<Map<String, Object>>() {});
+
+        VendoredJsManifest manifest = new VendoredJsManifest();
+        List<VendoredJsComponent> components = new ArrayList<>();
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> componentsList = (List<Map<String, Object>>) data.get("components");
+        if (componentsList != null) {
+            for (Map<String, Object> componentMap : componentsList) {
+                VendoredJsComponent component = new VendoredJsComponent();
+                component.setType(asString(componentMap.get("type")));
+                component.setName(asString(componentMap.get("name")));
+                component.setVersion(asString(componentMap.get("version")));
+                component.setPurl(asString(componentMap.get("purl")));
+                component.setSupplier(asString(componentMap.get("supplier")));
+                component.setCopyright(asString(componentMap.get("copyright")));
+                component.setNotes(asString(componentMap.get("notes")));
+
+                Object modifiedObj = componentMap.get("modified");
+                if (modifiedObj != null) {
+                    component.setModified(Boolean.parseBoolean(modifiedObj.toString()));
+                }
+
+                List<String> licenses = asStringList(componentMap.get("licenses"));
+                if (!licenses.isEmpty()) {
+                    component.setLicenses(licenses);
+                }
+
+                List<String> files = asStringList(componentMap.get("files"));
+                if (!files.isEmpty()) {
+                    component.setFiles(files);
+                }
+
+                components.add(component);
+            }
+        }
+
+        manifest.setComponents(components);
+        return manifest;
+    }
+
+    private static String asString(Object value) {
+        return value == null ? null : value.toString();
+    }
+
+    private static List<String> asStringList(Object value) {
+        if (!(value instanceof List)) {
+            return Collections.emptyList();
+        }
+
+        List<?> rawList = (List<?>) value;
+        List<String> result = new ArrayList<>(rawList.size());
+        for (Object item : rawList) {
+            if (item != null) {
+                result.add(item.toString());
+            }
+        }
+
+        return result;
+    }
+}

--- a/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/VendoredJsManifestParser.java
+++ b/maven-jahia-plugin/src/main/java/org/jahia/utils/maven/plugin/sbom/VendoredJsManifestParser.java
@@ -66,7 +66,10 @@ public class VendoredJsManifestParser {
     
     public static VendoredJsManifest parse(File manifestFile) throws IOException {
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-        Map<String, Object> data = mapper.readValue(new FileInputStream(manifestFile), new TypeReference<Map<String, Object>>() {});
+        Map<String, Object> data;
+        try (FileInputStream fis = new FileInputStream(manifestFile)) {
+            data = mapper.readValue(fis, new TypeReference<Map<String, Object>>() {});
+        }
 
         VendoredJsManifest manifest = new VendoredJsManifest();
         List<VendoredJsComponent> components = new ArrayList<>();

--- a/maven-jahia-plugin/src/test/java/org/jahia/tools/contentgenerator/junit/ContentGeneratorTestCase.java
+++ b/maven-jahia-plugin/src/test/java/org/jahia/tools/contentgenerator/junit/ContentGeneratorTestCase.java
@@ -73,7 +73,7 @@ public abstract class ContentGeneratorTestCase {
     protected static String CONTENT_EN = "CONTENT EN";
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp()  {
         contentGeneratorService = ContentGeneratorService.getInstance();
         createPages();
         createArticles();

--- a/maven-jahia-plugin/src/test/java/org/jahia/tools/contentgenerator/junit/PageServiceTest.java
+++ b/maven-jahia-plugin/src/test/java/org/jahia/tools/contentgenerator/junit/PageServiceTest.java
@@ -64,7 +64,7 @@ public class PageServiceTest extends ContentGeneratorTestCase {
 
     @Override
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         super.setUp();
         pageService = new ContentService();
     }

--- a/maven-jahia-plugin/src/test/java/org/jahia/tools/contentgenerator/junit/UserGroupServiceTest.java
+++ b/maven-jahia-plugin/src/test/java/org/jahia/tools/contentgenerator/junit/UserGroupServiceTest.java
@@ -55,7 +55,7 @@ public class UserGroupServiceTest extends ContentGeneratorTestCase{
 	private static UserGroupService userService;
 
 	@Before
-	public void setUp() throws Exception {
+	public void setUp() {
 		super.setUp();
 		userService = new UserGroupService();
 	}

--- a/maven-jahia-plugin/src/test/java/org/jahia/utils/maven/plugin/sbom/BomSerializerTest.java
+++ b/maven-jahia-plugin/src/test/java/org/jahia/utils/maven/plugin/sbom/BomSerializerTest.java
@@ -1,0 +1,147 @@
+/*
+ * ==========================================================================================
+ * =                   JAHIA'S DUAL LICENSING - IMPORTANT INFORMATION                       =
+ * ==========================================================================================
+ *
+ *                                 http://www.jahia.com
+ *
+ *     Copyright (C) 2002-2026 Jahia Solutions Group SA. All rights reserved.
+ *
+ *     THIS FILE IS AVAILABLE UNDER TWO DIFFERENT LICENSES:
+ *     1/GPL OR 2/JSEL
+ *
+ *     1/ GPL
+ *     ==================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE GPL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ *     2/ JSEL - Commercial and Supported Versions of the program
+ *     ===================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     Alternatively, commercial and supported versions of the program - also known as
+ *     Enterprises Distribution - must be used in accordance with the terms and conditions
+ *     contained in a separate written agreement between you and Jahia Solutions Group SA.
+ *
+ *     If you are unsure which license is appropriate for your use,
+ *     please contact the sales department at sales@jahia.com.
+ */
+package org.jahia.utils.maven.plugin.sbom;
+
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for {@link BomSerializer}.
+ */
+public class BomSerializerTest {
+
+    @Test
+    public void testSerializesToValidJson() throws Exception {
+        BomModel bom = createMinimalBom();
+
+        StringWriter writer = new StringWriter();
+        BomSerializer.serializeToJson(bom, writer);
+
+        String json = writer.toString();
+        assertNotNull(json);
+        assertFalse(json.trim().isEmpty());
+
+        // Validate it is parseable JSON
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(json);
+        assertNotNull(root);
+    }
+
+    @Test
+    public void testSerializedJsonContainsSpecVersion() throws Exception {
+        BomModel bom = createMinimalBom();
+
+        StringWriter writer = new StringWriter();
+        BomSerializer.serializeToJson(bom, writer);
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(writer.toString());
+
+        assertTrue("JSON must contain specVersion", root.has("specVersion"));
+        assertEquals("1.4", root.get("specVersion").asText());
+    }
+
+    @Test
+    public void testSerializedJsonContainsComponents() throws Exception {
+        BomModel bom = createMinimalBom();
+        ComponentModel component = new ComponentModel();
+        component.setType("library");
+        component.setName("test-lib");
+        component.setVersion("1.0.0");
+        bom.setComponents(Collections.singletonList(component));
+
+        StringWriter writer = new StringWriter();
+        BomSerializer.serializeToJson(bom, writer);
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(writer.toString());
+
+        assertTrue("JSON must contain components array", root.has("components"));
+        assertTrue(root.get("components").isArray());
+        assertEquals(1, root.get("components").size());
+        assertEquals("test-lib", root.get("components").get(0).get("name").asText());
+    }
+
+    @Test
+    public void testComponentLicenseSerializationStructure() throws Exception {
+        BomModel bom = createMinimalBom();
+        ComponentModel component = new ComponentModel();
+        component.setType("library");
+        component.setName("licensed-lib");
+        component.setVersion("1.0.0");
+        component.setLicenses(Arrays.asList(new ComponentModel.LicenseChoice("MIT")));
+        bom.setComponents(Collections.singletonList(component));
+
+        StringWriter writer = new StringWriter();
+        BomSerializer.serializeToJson(bom, writer);
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(writer.toString());
+
+        JsonNode licenses = root.get("components").get(0).get("licenses");
+        assertNotNull("Component must have licenses array", licenses);
+        assertTrue(licenses.isArray());
+        assertEquals(1, licenses.size());
+        JsonNode licenseEntry = licenses.get(0).get("license");
+        assertNotNull("License entry must have 'license' object", licenseEntry);
+        assertEquals("MIT", licenseEntry.get("id").asText());
+    }
+
+    private BomModel createMinimalBom() {
+        BomModel bom = new BomModel();
+        bom.setBomVersion("1");
+        bom.setSpecVersion("1.4");
+        bom.setVersion(1);
+        bom.setComponents(Collections.emptyList());
+        return bom;
+    }
+}

--- a/maven-jahia-plugin/src/test/java/org/jahia/utils/maven/plugin/sbom/GenerateVendoredJsBomMojoTest.java
+++ b/maven-jahia-plugin/src/test/java/org/jahia/utils/maven/plugin/sbom/GenerateVendoredJsBomMojoTest.java
@@ -1,0 +1,266 @@
+/*
+ * ==========================================================================================
+ * =                   JAHIA'S DUAL LICENSING - IMPORTANT INFORMATION                       =
+ * ==========================================================================================
+ *
+ *                                 http://www.jahia.com
+ *
+ *     Copyright (C) 2002-2026 Jahia Solutions Group SA. All rights reserved.
+ *
+ *     THIS FILE IS AVAILABLE UNDER TWO DIFFERENT LICENSES:
+ *     1/GPL OR 2/JSEL
+ *
+ *     1/ GPL
+ *     ==================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE GPL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ *     2/ JSEL - Commercial and Supported Versions of the program
+ *     ===================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     Alternatively, commercial and supported versions of the program - also known as
+ *     Enterprises Distribution - must be used in accordance with the terms and conditions
+ *     contained in a separate written agreement between you and Jahia Solutions Group SA.
+ *
+ *     If you are unsure which license is appropriate for your use,
+ *     please contact the sales department at sales@jahia.com.
+ */
+package org.jahia.utils.maven.plugin.sbom;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.lang.reflect.Field;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for {@link GenerateVendoredJsBomMojo}.
+ */
+public class GenerateVendoredJsBomMojoTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    /**
+     * Creates a mojo instance with fields set via reflection (matching how Maven injects parameters).
+     */
+    private GenerateVendoredJsBomMojo createMojo(File basedir, File outputDirectory, String manifestFile)
+            throws Exception {
+        GenerateVendoredJsBomMojo mojo = new GenerateVendoredJsBomMojo();
+        setField(mojo, "basedir", basedir);
+        setField(mojo, "outputDirectory", outputDirectory);
+        setField(mojo, "manifestFile", manifestFile);
+        setField(mojo, "outputFileName", "vendored-js-bom.cdx");
+        setField(mojo, "skipIfMissing", true);
+        return mojo;
+    }
+
+    private void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    @Test
+    public void testSkipsExecutionWhenManifestMissing() throws Exception {
+        File basedir = tmpFolder.newFolder("project");
+        File outputDir = tmpFolder.newFolder("output");
+
+        GenerateVendoredJsBomMojo mojo = createMojo(basedir, outputDir, "vendored-js.yaml");
+        // Should not throw — skipIfMissing is true by default
+        mojo.execute();
+
+        // No BOM file should be generated
+        assertFalse(new File(outputDir, "vendored-js-bom.cdx.json").exists());
+    }
+
+    @Test
+    public void testGeneratesBomFromManifest() throws Exception {
+        File basedir = tmpFolder.newFolder("project");
+        File outputDir = tmpFolder.newFolder("output");
+
+        // Create a simple JS file for hashing
+        File jsDir = new File(basedir, "src/main/resources/javascript");
+        jsDir.mkdirs();
+        File jsFile = new File(jsDir, "lib.js");
+        try (FileWriter fw = new FileWriter(jsFile)) {
+            fw.write("/* test library */");
+        }
+
+        // Write a minimal manifest
+        File manifest = new File(basedir, "vendored-js.yaml");
+        try (FileWriter fw = new FileWriter(manifest)) {
+            fw.write("components:\n");
+            fw.write("  - name: test-lib\n");
+            fw.write("    version: \"1.0.0\"\n");
+            fw.write("    type: library\n");
+            fw.write("    licenses:\n");
+            fw.write("      - MIT\n");
+            fw.write("    files:\n");
+            fw.write("      - src/main/resources/javascript/lib.js\n");
+        }
+
+        GenerateVendoredJsBomMojo mojo = createMojo(basedir, outputDir, "vendored-js.yaml");
+        mojo.execute();
+
+        File bomFile = new File(outputDir, "vendored-js-bom.cdx.json");
+        assertTrue("BOM file should be generated", bomFile.exists());
+
+        // Validate JSON structure
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(bomFile);
+
+        assertEquals("1.4", root.get("specVersion").asText());
+        assertTrue(root.has("components"));
+        assertEquals(1, root.get("components").size());
+
+        JsonNode component = root.get("components").get(0);
+        assertEquals("test-lib", component.get("name").asText());
+        assertEquals("1.0.0", component.get("version").asText());
+        assertEquals("library", component.get("type").asText());
+    }
+
+    @Test
+    public void testHashesAreComputedForExistingFiles() throws Exception {
+        File basedir = tmpFolder.newFolder("project");
+        File outputDir = tmpFolder.newFolder("output");
+
+        File jsDir = new File(basedir, "js");
+        jsDir.mkdirs();
+        File jsFile = new File(jsDir, "app.js");
+        try (FileWriter fw = new FileWriter(jsFile)) {
+            fw.write("console.log('hello');");
+        }
+
+        File manifest = new File(basedir, "vendored-js.yaml");
+        try (FileWriter fw = new FileWriter(manifest)) {
+            fw.write("components:\n");
+            fw.write("  - name: app\n");
+            fw.write("    version: \"1.0\"\n");
+            fw.write("    files:\n");
+            fw.write("      - js/app.js\n");
+        }
+
+        GenerateVendoredJsBomMojo mojo = createMojo(basedir, outputDir, "vendored-js.yaml");
+        mojo.execute();
+
+        File bomFile = new File(outputDir, "vendored-js-bom.cdx.json");
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(bomFile);
+
+        JsonNode hashes = root.get("components").get(0).get("hashes");
+        assertNotNull("Hashes should be present for existing files", hashes);
+        assertTrue(hashes.isArray());
+        assertEquals(1, hashes.size());
+        assertEquals("SHA-256", hashes.get(0).get("alg").asText());
+
+        String hashContent = hashes.get(0).get("content").asText();
+        assertNotNull(hashContent);
+        // SHA-256 hex string should be 64 characters
+        assertEquals(64, hashContent.length());
+    }
+
+    @Test
+    public void testDirectoryReferenceDoesNotProduceHash() throws Exception {
+        File basedir = tmpFolder.newFolder("project");
+        File outputDir = tmpFolder.newFolder("output");
+
+        // Create a directory reference in the manifest (no individual file listed)
+        File jsDir = new File(basedir, "vendor/moment");
+        jsDir.mkdirs();
+        new File(jsDir, "moment.js").createNewFile();
+
+        File manifest = new File(basedir, "vendored-js.yaml");
+        try (FileWriter fw = new FileWriter(manifest)) {
+            fw.write("components:\n");
+            fw.write("  - name: moment\n");
+            fw.write("    version: \"2.29.1\"\n");
+            fw.write("    files:\n");
+            fw.write("      - vendor/moment/\n");
+        }
+
+        GenerateVendoredJsBomMojo mojo = createMojo(basedir, outputDir, "vendored-js.yaml");
+        mojo.execute();
+
+        File bomFile = new File(outputDir, "vendored-js-bom.cdx.json");
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(bomFile);
+
+        // Directory entries are not regular files, so no hash should be produced
+        JsonNode hashes = root.get("components").get(0).get("hashes");
+        // hashes may be null or an empty array since the path points to a directory
+        assertTrue("Directory reference should not produce file hashes",
+                hashes == null || hashes.isNull() || hashes.size() == 0);
+    }
+
+    @Test
+    public void testPropertiesContainSourcePathsAndComponentSource() throws Exception {
+        File basedir = tmpFolder.newFolder("project");
+        File outputDir = tmpFolder.newFolder("output");
+
+        File jsDir = new File(basedir, "js");
+        jsDir.mkdirs();
+        File jsFile = new File(jsDir, "util.js");
+        try (FileWriter fw = new FileWriter(jsFile)) {
+            fw.write("/* util */");
+        }
+
+        File manifest = new File(basedir, "vendored-js.yaml");
+        try (FileWriter fw = new FileWriter(manifest)) {
+            fw.write("components:\n");
+            fw.write("  - name: util\n");
+            fw.write("    version: \"0.1\"\n");
+            fw.write("    files:\n");
+            fw.write("      - js/util.js\n");
+        }
+
+        GenerateVendoredJsBomMojo mojo = createMojo(basedir, outputDir, "vendored-js.yaml");
+        mojo.execute();
+
+        File bomFile = new File(outputDir, "vendored-js-bom.cdx.json");
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(bomFile);
+
+        JsonNode properties = root.get("components").get(0).get("properties");
+        assertNotNull("Properties should be present", properties);
+        assertTrue(properties.isArray());
+
+        boolean hasSourcePaths = false;
+        boolean hasComponentSource = false;
+        for (JsonNode prop : properties) {
+            String name = prop.get("name").asText();
+            if ("jahia:source-paths".equals(name)) {
+                hasSourcePaths = true;
+            }
+            if ("jahia:component-source".equals(name)) {
+                assertEquals("vendored-javascript", prop.get("value").asText());
+                hasComponentSource = true;
+            }
+        }
+        assertTrue("Property jahia:source-paths should be present", hasSourcePaths);
+        assertTrue("Property jahia:component-source should be present", hasComponentSource);
+    }
+}

--- a/maven-jahia-plugin/src/test/java/org/jahia/utils/maven/plugin/sbom/VendoredJsManifestParserTest.java
+++ b/maven-jahia-plugin/src/test/java/org/jahia/utils/maven/plugin/sbom/VendoredJsManifestParserTest.java
@@ -1,0 +1,138 @@
+/*
+ * ==========================================================================================
+ * =                   JAHIA'S DUAL LICENSING - IMPORTANT INFORMATION                       =
+ * ==========================================================================================
+ *
+ *                                 http://www.jahia.com
+ *
+ *     Copyright (C) 2002-2026 Jahia Solutions Group SA. All rights reserved.
+ *
+ *     THIS FILE IS AVAILABLE UNDER TWO DIFFERENT LICENSES:
+ *     1/GPL OR 2/JSEL
+ *
+ *     1/ GPL
+ *     ==================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE GPL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ *     2/ JSEL - Commercial and Supported Versions of the program
+ *     ===================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     Alternatively, commercial and supported versions of the program - also known as
+ *     Enterprises Distribution - must be used in accordance with the terms and conditions
+ *     contained in a separate written agreement between you and Jahia Solutions Group SA.
+ *
+ *     If you are unsure which license is appropriate for your use,
+ *     please contact the sales department at sales@jahia.com.
+ */
+package org.jahia.utils.maven.plugin.sbom;
+
+import java.io.File;
+import java.net.URL;
+import java.util.List;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for {@link VendoredJsManifestParser}.
+ */
+public class VendoredJsManifestParserTest {
+
+    private File getTestResource(String name) {
+        URL resource = getClass().getResource(name);
+        assertNotNull("Test resource not found: " + name, resource);
+        return new File(resource.getFile());
+    }
+
+    @Test
+    public void testParseBasicManifest() throws Exception {
+        File manifest = getTestResource("vendored-js-test.yaml");
+        VendoredJsManifest result = VendoredJsManifestParser.parse(manifest);
+
+        assertNotNull(result);
+        List<VendoredJsComponent> components = result.getComponents();
+        assertNotNull(components);
+        assertEquals(2, components.size());
+    }
+
+    @Test
+    public void testParseComponentFields() throws Exception {
+        File manifest = getTestResource("vendored-js-test.yaml");
+        VendoredJsManifest result = VendoredJsManifestParser.parse(manifest);
+
+        VendoredJsComponent jquery = result.getComponents().get(0);
+        assertEquals("jquery", jquery.getName());
+        assertEquals("3.6.0", jquery.getVersion());
+        assertEquals("library", jquery.getType());
+        assertEquals("pkg:npm/jquery@3.6.0", jquery.getPurl());
+        assertEquals("jQuery Foundation", jquery.getSupplier());
+        assertEquals("Copyright JS Foundation and other contributors", jquery.getCopyright());
+        assertEquals("Minified jQuery library", jquery.getNotes());
+        assertFalse(jquery.isModified());
+    }
+
+    @Test
+    public void testParseLicenses() throws Exception {
+        File manifest = getTestResource("vendored-js-test.yaml");
+        VendoredJsManifest result = VendoredJsManifestParser.parse(manifest);
+
+        VendoredJsComponent jquery = result.getComponents().get(0);
+        List<String> licenses = jquery.getLicenses();
+        assertNotNull(licenses);
+        assertEquals(1, licenses.size());
+        assertEquals("MIT", licenses.get(0));
+    }
+
+    @Test
+    public void testParseFiles() throws Exception {
+        File manifest = getTestResource("vendored-js-test.yaml");
+        VendoredJsManifest result = VendoredJsManifestParser.parse(manifest);
+
+        VendoredJsComponent jquery = result.getComponents().get(0);
+        List<String> files = jquery.getFiles();
+        assertNotNull(files);
+        assertEquals(1, files.size());
+        assertEquals("src/main/resources/javascript/jquery/jquery.min.js", files.get(0));
+    }
+
+    @Test
+    public void testParseDirectoryReference() throws Exception {
+        File manifest = getTestResource("vendored-js-test.yaml");
+        VendoredJsManifest result = VendoredJsManifestParser.parse(manifest);
+
+        VendoredJsComponent moment = result.getComponents().get(1);
+        List<String> files = moment.getFiles();
+        assertNotNull(files);
+        assertEquals(1, files.size());
+        assertEquals("src/main/resources/javascript/moment/", files.get(0));
+        assertTrue(moment.isModified());
+    }
+
+    @Test
+    public void testParseEmptyManifest() throws Exception {
+        File manifest = getTestResource("vendored-js-empty.yaml");
+        VendoredJsManifest result = VendoredJsManifestParser.parse(manifest);
+
+        assertNotNull(result);
+        assertNotNull(result.getComponents());
+        assertTrue(result.getComponents().isEmpty());
+    }
+}

--- a/maven-jahia-plugin/src/test/resources/org/jahia/utils/maven/plugin/sbom/vendored-js-empty.yaml
+++ b/maven-jahia-plugin/src/test/resources/org/jahia/utils/maven/plugin/sbom/vendored-js-empty.yaml
@@ -1,0 +1,1 @@
+components:

--- a/maven-jahia-plugin/src/test/resources/org/jahia/utils/maven/plugin/sbom/vendored-js-test.yaml
+++ b/maven-jahia-plugin/src/test/resources/org/jahia/utils/maven/plugin/sbom/vendored-js-test.yaml
@@ -1,0 +1,21 @@
+components:
+  - name: jquery
+    version: "3.6.0"
+    type: library
+    purl: "pkg:npm/jquery@3.6.0"
+    supplier: "jQuery Foundation"
+    copyright: "Copyright JS Foundation and other contributors"
+    licenses:
+      - MIT
+    files:
+      - src/main/resources/javascript/jquery/jquery.min.js
+    modified: false
+    notes: "Minified jQuery library"
+  - name: moment
+    version: "2.29.1"
+    type: library
+    licenses:
+      - MIT
+    files:
+      - src/main/resources/javascript/moment/
+    modified: true

--- a/pom.xml
+++ b/pom.xml
@@ -203,17 +203,17 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.15.2</version>
+                <version>2.22</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.15.2</version>
+                <version>2.22.0</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-yaml</artifactId>
-                <version>2.15.2</version>
+                <version>2.22.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.scm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -203,12 +203,17 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.12.4</version>
+                <version>2.15.2</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.12.4</version>
+                <version>2.15.2</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
+                <version>2.15.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.scm</groupId>


### PR DESCRIPTION
* feat: introduce new jahia maven plugin goal: generate-vendored-js-bom

* Implemented also goal for validation phase: validate-vendored-js-manifest

### Description

Repositories of some legacy modules in Jahia contains directly commited javascript libraries. The cyclonedx plugins are not detecting them as they have no reference to a package manager. Therefore we need to manually create a SBOM file for these libraries as long as such modules are supported.

These modules need to have a `vendored-js.yaml` manifest in the root folder, which declares manually packaged JavaScript libraries that are not pulled from npm or other package managers. This manifest is read by the `jahia:generate-vendored-js-bom` goal to generate a CycloneDX 1.4 SBOM that includes these assets in the vulnerability monitoring pipeline.

## Structure

```yaml
# Top-level: components list
components:
  - name: library-name
    type: library
    version: 1.2.3
    purl: pkg:npm/library-name@1.2.3  # Optional but recommended
    supplier: Library Vendor               # Optional
    copyright: Copyright Library Vendor     # Optional and used from CycloneDX 1.5 spec onwards
    licenses:                              # Optional
      - MIT
      - Apache-2.0
    files:                                 # Required: relative to basedir, can also reference a folder
      - path/to/file1.js
      - path/to/file2.js
      - path/to/subfolder/file3.js
    modified: false                        # Optional: true if locally patched/minified
    notes: Optional notes about this library # Optional
```

## Field Definitions

| Field | Type | Required | Description |
|-------|------|----------|-------------|
| `name` | string | Yes | The name of the library (e.g., `jquery`, `codemirror`) |
| `type` | string | No | The component type required from CycloneDX spec 1.5 onwards - mainly: `library` |
| `version` | string | Yes | Upstream library version (e.g., `1.12.4`). Use `unknown` if version cannot be determined. |
| `purl` | string | No | **Package URL (highly recommended for CVE matching)**. Use `pkg:npm/name@version` if available on npm, otherwise `pkg:generic/name@version`. See https://github.com/package-url/purl-spec. **Best practice**: Always check npm registry first; use `pkg:npm/` for better Dependency-Track CVE correlation. |
| `supplier` | string | No | Upstream library supplier/organization (e.g., `jQuery Foundation`) |
| `copyright` | string | No | The copyright statement taken from the sources |
| `licenses` | array | No | SPDX license identifiers (e.g., `MIT`, `Apache-2.0`) |
| `files` | array | Yes | Relative paths (from basedir) to the actual JS files for this library. Can be individual files or patterns. |
| `modified` | boolean | No | Set to `true` if the file is locally modified, minified, or patched from upstream. Defaults to `false`. |
| `notes` | string | No | Free-text notes about this library (e.g., "Jahia wrapper/minified variant", "Includes security patches") |

The goal could be added to the jahia-parent/modules/pom.ml like this:
```xml
<!-- In <pluginManagement> section -->
<plugin>
    <groupId>org.jahia.server</groupId>
    <artifactId>jahia-maven-plugin</artifactId>
    <version>${jahia.plugin.version}</version>
    <executions>
        <!-- Existing executions... -->
        
        <!-- Add this execution for vendored JS BOM generation -->
        <execution>
            <id>generate-vendored-js-bom</id>
            <phase>process-resources</phase>
            <goals>
                <goal>generate-vendored-js-bom</goal>
            </goals>
            <configuration>
                <!-- Default: vendored-js.yaml in project root -->
                <manifestFile>vendored-js.yaml</manifestFile>
                <!-- Default: target/ -->
                <outputDirectory>${project.build.directory}</outputDirectory>
                <!-- Default: vendored-js-bom.cdx -->
                <outputFileName>vendored-js-bom.cdx</outputFileName>
                <!-- Skip silently if manifest doesn't exist (opt-in per repo) -->
                <skipIfMissing>true</skipIfMissing>
            </configuration>
        </execution>

        <!-- Optional: validation goal (runs at validate phase) -->
        <execution>
            <id>validate-vendored-js-manifest</id>
            <phase>validate</phase>
            <goals>
                <goal>validate-vendored-js-manifest</goal>
            </goals>
            <configuration>
                <!-- Comma-separated; set in child pom or skip if no vendored JS -->
                <vendoredJsDirectories>src/main/resources/javascript</vendoredJsDirectories>
                <skipIfNoManifest>true</skipIfNoManifest>
                <!-- Optional: patterns to exclude from validation -->
                <excludePatterns>jquery.jahia.js,jquery.jahia.min.js,treeselector.js,admin-bootstrap.js,workInProgress.js,jquery.sortElements.js,i18n/</excludePatterns>
            </configuration>
        </execution>
    </executions>
</plugin>
```

This would create the SBOM for all modules referencing that latest version of Jahia, However we usually keep the parent dependency of the modules on older Jahia versions. Therefore we may have to add these lines to the individual modules, which still have directly commited libraries.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)